### PR TITLE
Feature/mcrun (#10)

### DIFF
--- a/src/Configurations.jl
+++ b/src/Configurations.jl
@@ -118,7 +118,7 @@ end
 Base.length(::Config{N}) where N = N
 
 
-"""
+#= """
     move_atom!(pos, delta_move, bc)
 
 Moves an atom at position `pos` by `delta_move`.
@@ -127,7 +127,7 @@ implemented for:
     - `SphericalBC`: trial move is repeated until moved atom is within binding sphere
     - `CubicBC`: (to be added) periodic boundary condition implemented
 
-"""
+""" =#
 #function move_atom!(config::Config, n_atom, delta_move)
 #    config.pos[n_atom] += delta_move
 #    return config

--- a/src/InputParams.jl
+++ b/src/InputParams.jl
@@ -1,5 +1,5 @@
 """ 
-    module Input
+    module InputParams
 
     this module provides structs and methods to arrange input parameters
 """
@@ -13,21 +13,48 @@ using ..EnergyEvaluation
 
 export InputParameters
 export MCParams, TempGrid
-export AbstractDisplacementParams, DisplacementParamsAtomMove
+export Output
+#export Results
+#export AbstractDisplacementParams, DisplacementParamsAtomMove
 
 const kB = 3.16681196E-6  # in Hartree/K (3.166811429E-6)
 
+"""
+    MCParams(cycles, n_traj, n_atoms; eq_percentage = 0.2, mc_sample = 1, n_adjust = 100)
+Type that collects MC specific data: 
+- number of MC cycles `cycles`, temperatures `n_traj` and atoms `n_atom`
+- percentage of equilibration: default 20%
+- frequency of sampling energy (adding to Markov chain): 
+`mc_sample` gives number of MC cycles after which energy is saved (default: 1)
+- step size of moves is automatically adjusted after `n_adjust` MC cycles (default: 100)
+"""
 struct MCParams
     mc_cycles::Int
     eq_cycles::Int
+    mc_sample::Int
+    n_traj::Int
+    n_atoms::Int
+    n_adjust::Int
 end 
 
-function MCParams(cycles; eq_percentage = 0.2)
+function MCParams(cycles, n_traj, n_atoms; eq_percentage = 0.2, mc_sample = 1, n_adjust = 100)
     mc_cycles = Int(cycles)
     eq_cycles = round(Int, eq_percentage * mc_cycles)
-    return MCParams(mc_cycles,eq_cycles)
+    return MCParams(mc_cycles, eq_cycles, mc_sample, n_traj, n_atoms, n_adjust)
 end
 
+"""
+    TempGrid{N}(ti, tf; tdistr) 
+    TempGrid(ti, tf, N; tdistr=:geometric)
+Generates grid of `N` temperatures and inverse temperatures for MC calculation
+between initial and final temperatures `ti` and `tf`
+Field names:
+- `t_grid`: temperatures (in K)
+- `beta_grid`: inverse temperatures (in atomic units)
+keyword argument `tdistr`:
+- :geometric (default): generates geometric temperature distribution
+- :equally_spaced: generates equally spaced temperature grid
+"""
 struct TempGrid{N,T} 
     t_grid::SVector{N,T}
     beta_grid::SVector{N,T}
@@ -42,48 +69,86 @@ function TempGrid{N}(ti, tf; tdistr=:geometric) where {N}
     else
         throw(ArgumentError("chosen temperature distribution $tdistr does not exist"))
     end
-    betagrid = 1. /(kB*tgrid)
+    betagrid = 1. ./ (kB .* tgrid)
     return TempGrid{N,eltype(tgrid)}(SVector{N}(tgrid), SVector{N}(betagrid))
 end 
 
 TempGrid(ti, tf, N; tdistr=:geometric) = TempGrid{N}(ti, tf; tdistr)
 
-abstract type AbstractDisplacementParams{T} end
+"""
+    Output{T}(n_bin; en_min = 0)
+Collects output of MC calculation:
+- `n_bin`: number of energy bins for histograms
+- `en_min`: minimum energy found during calculation
+- `max_displ`: final maximum displacements
+- `en_avg`: inner energy U(T) (as average over sampled energies)
+- `heat_cap`: heat capacities C(T) 
+- `rdf`: radial distribution information
+- `count_stat_*`: statistics of accepted atom, volume and rotation moves 
+and attempted and successful parallel-tempering exchanges
+"""
+mutable struct Output{T}
+    n_bin::Int
+    en_min::T
+    max_displ::Vector{T}
+    en_avg::Vector{T}
+    heat_cap::Vector{T}
+    en_histogram::Vector{EnHist}
+    rdf::Vector{T}
+    count_stat_atom::Vector{T}
+    count_stat_vol::Vector{T}
+    count_stat_rot::Vector{T}
+    count_stat_exc::Vector{T}
+end
 
-struct DisplacementParamsAtomMove{T} <: AbstractDisplacementParams{T}
-    max_displacement::Vector{T} #maximum atom displacement in Angstrom
-    update_step::Int
-end 
+function Output{T}(n_bin; en_min = 0) where T
+    en_min = 0.
+    max_displ = T[]
+    en_avg = T[]
+    heat_cap = T[]
+    en_histogram = EnHist[]
+    rdf = T[]
+    count_stat_atom = T[]
+    count_stat_vol = T[]
+    count_stat_rot = T[]
+    count_stat_exc = T[]
+    return Output{T}(n_bin, en_min, max_displ, en_avg, heat_cap, en_histogram, rdf, count_stat_atom, count_stat_vol, count_stat_rot, count_stat_exc)
+end
 
-function DisplacementParamsAtomMove(displ,tgrid; update_stepsize=100)
-    T = eltype(displ)
-    N = length(tgrid)
+#struct DisplacementParamsAtomMove{T} <: AbstractDisplacementParams{T}
+#    max_displacement::Vector{T} #maximum atom displacement in Angstrom
+#    update_step::Int
+#end 
+
+#function DisplacementParamsAtomMove(displ,tgrid; update_stepsize=100)
+#    T = eltype(displ)
+#    N = length(tgrid)
     #initialize displacement vector
-    max_displ = [0.1*sqrt(displ*tgrid[i]) for i in 1:N]
-    return DisplacementParamsAtomMove{T}(max_displ, update_stepsize)
-end
+#    max_displ = [0.1*sqrt(displ*tgrid[i]) for i in 1:N]
+#    return DisplacementParamsAtomMove{T}(max_displ, update_stepsize)
+#end
 
-function update_max_stepsize!(displ::DisplacementParamsAtomMove, count_accept, n_atom)
-    for i in 1:length(count_acc)
-        acc_rate =  count_accept[i] / (displ.update_step * n_atom)
-        if acc_rate < 0.4
-            displ.max_displacement[i] *= 0.9
-        elseif acc_rate > 0.6
-            displ.max_displacement[i] *= 1.1
-        end
-        count_accept[i] = 0
-    end
-    return displ, count_accept
-end
+#function update_max_stepsize!(displ::DisplacementParamsAtomMove, count_accept, n_atom)
+#    for i in 1:length(count_acc)
+#       acc_rate =  count_accept[i] / (displ.update_step * n_atom)
+#        if acc_rate < 0.4
+#            displ.max_displacement[i] *= 0.9
+#        elseif acc_rate > 0.6
+#            displ.max_displacement[i] *= 1.1
+#        end
+#        count_accept[i] = 0
+#    end
+#    return displ, count_accept
+#end
 
-struct InputParameters
+#= struct InputParameters
     mc_parameters::MCParams
     temp_parameters::TempGrid
     starting_conf::Config
     random_seed::Int
     potential::AbstractPotential
-    max_displacement::AbstractDisplacementParams
-end
+#    max_displacement::AbstractDisplacementParams
+end =#
 
 #bc_ar32 = SphericalBC(radius=14.5)  #Angstrom
 

--- a/src/MCMoves.jl
+++ b/src/MCMoves.jl
@@ -1,12 +1,48 @@
 module MCMoves
 
-export AbstractMove
+export MoveStrategy, atom_move_frequency, vol_move_frequency, rot_move_frequency
+export AbstractMove, StatMove
 export AtomMove
-export atom_displacement
+export atom_displacement, update_max_stepsize!
 
 using StaticArrays
 
 using ..BoundaryConditions
+
+"""
+    MoveStrategy(atom_moves, vol_moves, rot_moves)
+    MoveStrategy(;atom_moves=1, vol_moves=0, rot_moves=0)
+Type that implements move strategy containing information of frequencies of moves:
+ - atom_moves:  frequency of atom moves
+ - vol_moves:  frequency of volume moves
+ - rot_moves:  frequency of rotation moves
+"""
+struct MoveStrategy{A,V,R}
+end 
+
+function MoveStrategy(a,v,r)
+    return MoveStrategy{a,v,r}()
+end
+
+function MoveStrategy(;atom_moves=1, vol_moves=0, rot_moves=0)
+    return MoveStrategy(atom_moves,vol_moves,rot_moves)
+end 
+
+"""
+    atom_move_frequency(ms::MoveStrategy{A,V,R})
+gives frequency of atom moves    
+"""
+atom_move_frequency(ms::MoveStrategy{A,V,R}) where {A,V,R} = A 
+"""
+    vol_move_frequency(ms::MoveStrategy{A,V,R})
+gives frequency of volume moves    
+"""
+vol_move_frequency(ms::MoveStrategy{A,V,R}) where {A,V,R} = V
+"""
+    rot_move_frequency(ms::MoveStrategy{A,V,R})
+gives frequency of rotation moves    
+"""
+rot_move_frequency(ms::MoveStrategy{A,V,R}) where {A,V,R} = R
 
 """
     AbstractMove
@@ -20,9 +56,22 @@ abstract type AbstractMove end
     AtomMove
 implements type for atom move (random displacement of randomly selected atom)
 field name: frequency: number of moves per Monte Carlo cycle
+            max_displacement: max. displacement for move per temperature (updated during MC run)
+            n_update_stepsize: number of MC cycles between update of max. displacement
+            count_acc: total number of accepted atom moves
+            count_acc_adj: number of accepted moves between stepsize adjustments 
 """
-struct AtomMove <: AbstractMove
+mutable struct AtomMove{T} <: AbstractMove
     frequency::Int
+    max_displacement::T
+    n_update_stepsize::Int
+    count_acc::Int       
+    count_acc_adj::Int 
+end
+
+function AtomMove(frequency, displ; update_stepsize=100, count_acc=0, count_acc_adj=0)
+    T = eltype(displ)
+    return AtomMove{T}(frequency, displ, update_stepsize, count_acc, count_acc_adj)
 end
 
 """
@@ -49,6 +98,25 @@ function atom_displacement(pos, max_displacement, bc::SphericalBC)
     return trial_pos
 end
 
-
+"""
+    update_max_stepsize!(displ, n_update, count_accept, n_atom)
+update of maximum step size of atom moves after n_update MC cyles (n_atom moves per cycle)
+depends on ratio of accepted moves - as given in count_accept - 
+for acceptance ratio < 40% max_displacement is reduced to 90% of its value,
+for acceptance ratio > 60% max_displacement is increased to 110% of its value.
+count_accept is set back to zero at end.      
+"""
+function update_max_stepsize!(displ, n_update, count_accept, n_atom)
+    for i in 1:length(count_accept)
+        acc_rate =  count_accept[i] / (n_update * n_atom)
+        if acc_rate < 0.4
+            displ[i] *= 0.9
+        elseif acc_rate > 0.6
+            displ[i] *= 1.1
+        end
+        count_accept[i] = 0
+    end
+    return displ, count_accept
+end
 
 end #module

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -1,6 +1,9 @@
 module MCRun
 
-export metropolis_condition, mc_step_atom!
+export MCState
+export metropolis_condition, mc_step!, mc_cycle!, ptmc_run!
+export atom_move!
+export exc_acceptance, exc_trajectories!
 
 using StaticArrays
 
@@ -8,38 +11,359 @@ using ..BoundaryConditions
 using ..Configurations
 using ..InputParams
 using ..MCMoves
+using ..EnergyEvaluation
 
 """
-    metropolis_condition(energy_unmoved, energy_moved, beta)
+    MCState(temp, beta, config::Config{N,BC,T}, dist2_mat, en_atom_vec, en_tot; 
+        max_displ = [0.1,0.1,1.], count_atom = [0,0], count_vol = [0,0], count_rot = [0,0], count_exc = [0,0])
+    MCState(temp, beta, config::Config, pot; kwargs...) 
+Creates an MC state vector at a given temperature `temp` containing temperature-dependent information
 
-Determines probability to accept a MC move at inverse temperature beta, takes energies of new and old configurations
+Fieldnames:
+- `temp`: temperature
+- `beta`: inverse temperature
+- `config`: actual configuration in Markov chain [`Config`](@ref)  
+- `dist_2mat`: matrix of squared distances d_ij between atoms i and j; generated automatically when potential `pot` given
+- `en_atom_vec`: vector of energy contributions per atom i; generated automatically when `pot` given
+- `en_tot`: total energy of `config`; generated automatically when `pot` given
+- `ham`: vector containing sampled energies - generated in MC run
+- `max_displ`: max_diplacements for atom, volume and rotational moves; key-word argument
+- `count_atom`: number of accepted atom moves - total and between adjustment of step sizes; key-word argument
+- `count_vol`: number of accepted volume moves - total and between adjustment of step sizes; key-word argument
+- `count_rot`: number of accepted rotational moves - total and between adjustment of step sizes; key-word argument
+- `count_exc`: number of attempted (10%) and accepted exchanges with neighbouring trajectories; key-word argument
 """
-function metropolis_condition(energy_unmoved, energy_moved, beta)
-    prob_val = exp(-(energy_moved-energy_unmoved)*beta)
+mutable struct MCState{T,N,BC}
+    temp::T
+    beta::T
+    config::Config{N,BC,T}
+    dist2_mat::Matrix{T}
+    en_atom_vec::Vector{T}
+    en_tot::T
+    ham::Vector{T}
+    max_displ::Vector{T}
+    count_atom::Vector{Int}
+    count_vol::Vector{Int}
+    count_rot::Vector{Int}
+    count_exc::Vector{Int}
+end    
+
+function MCState(
+    temp, beta, config::Config{N,BC,T}, dist2_mat, en_atom_vec, en_tot; 
+    max_displ = [0.1,0.1,1.], count_atom = [0,0], count_vol = [0,0], count_rot = [0,0], count_exc = [0,0]
+) where {T,N,BC}
+    ham = T[]
+    MCState{T,N,BC}(
+        temp, beta, deepcopy(config), copy(dist2_mat), copy(en_atom_vec), en_tot, 
+        ham, copy(max_displ), copy(count_atom), copy(count_vol), copy(count_rot), copy(count_exc)
+        )
+end
+
+function MCState(temp, beta, config::Config, pot; kwargs...) 
+   dist2_mat = get_distance2_mat(config)
+   n_atoms = length(config.pos)
+   en_atom_vec, en_tot = dimer_energy_config(dist2_mat, n_atoms, pot)
+   MCState(temp, beta, config, dist2_mat, en_atom_vec, en_tot; kwargs...)
+end
+
+"""
+    metropolis_condition(ensemble, delta_en, beta)
+Returns probability to accept a MC move at inverse temperature `beta` 
+for energy difference `delta_en` between new and old configuration 
+for given ensemble; implemented: 
+    - `NVT`: canonical ensemble
+Asymmetric Metropolis criterium, p = 1.0 if new configuration more stable, 
+Boltzmann probability otherwise
+"""
+function metropolis_condition(::NVT, delta_en, beta)
+    prob_val = exp(-delta_en*beta)
     T = typeof(prob_val)
     return ifelse(prob_val > 1, T(1), prob_val)
 end
 
-function mc_step_atom!(config, beta, dist2_mat, en_tot, i_atom, max_displacement, count_acc, count_acc_adjust, pot)
+#function metropolis_condition(energy_unmoved, energy_moved, beta)
+#    prob_val = exp(-(energy_moved-energy_unmoved)*beta)
+#    T = typeof(prob_val)
+#    return ifelse(prob_val > 1, T(1), prob_val)
+#end
+
+
+"""
+    exc_acceptance(beta_1, beta_2, en_1, en_2)
+Returns probability to exchange configurations of two trajectories with energies `en_1` and `en_2` 
+at inverse temperatures `beta_1` and `beta_2`. 
+"""
+function exc_acceptance(beta_1, beta_2, en_1, en_2)
+    delta_en = en_1 - en_2
+    delta_beta = beta_1 - beta_2
+    exc_acc = min(1.0,exp(delta_beta * delta_en))
+    return exc_acc
+end
+
+"""
+    exc_trajectories!(state_1::MCState, state_2::MCState)
+Exchanges configurations and distance and energy information between two trajectories;
+information contained in `state_1` and `state_2`, see [`MCState`](@ref)   
+"""
+function exc_trajectories!(state_1::MCState, state_2::MCState)
+    state_1.config, state_2.config = state_2.config, state_1.config
+    state_1.dist2_mat, state_2.dist2_mat = state_2.dist2_mat, state_1.dist2_mat
+    state_1.en_atom_vec, state_2.en_atom_vec = state_2.en_atom_vec, state_1.en_atom_vec
+    state_1.en_tot, state_2.en_tot = state_2.en_tot, state_1.en_tot
+    return state_1, state_2
+end 
+
+
+"""
+    update_max_stepsize!(mc_state::MCState, n_update, a, v, r)
+Increases/decreases the max. displacement of atom, volume, and rotation moves to 110%/90% of old values
+if acceptance rate is >60%/<40%. Acceptance rate is calculated after `n_update` MC cycles; 
+each cycle consists of `a` atom, `v` volume and `r` rotation moves.
+Information on actual max. displacement and accepted moves between updates is contained in `mc_state`, see [`MCState`](@ref).  
+"""
+function update_max_stepsize!(mc_state::MCState, n_update, a, v, r)
+    #atom moves
+    acc_rate = mc_state.count_atom[2] / (n_update * a)
+    if acc_rate < 0.4
+        mc_state.max_displ[1] *= 0.9
+    elseif acc_rate > 0.6
+        mc_state.max_displ[1] *= 1.1
+    end
+    mc_state.count_atom[2] = 0
+    #volume moves
+    if v > 0
+        acc_rate = mc_state.count_vol[2] / (n_update * v)
+        if acc_rate < 0.4
+            mc_state.max_displ[2] *= 0.9
+        elseif acc_rate > 0.6
+            mc_state.max_displ[2] *= 1.1
+        end
+        mc_state.count_vol[2] = 0
+    end
+    #rotation moves
+    if r > 0
+        acc_rate = mc_state.count_rot[2] / (n_update * r)
+        if acc_rate < 0.4
+            mc_state.max_displ[3] *= 0.9
+        elseif acc_rate > 0.6
+            mc_state.max_displ[3] *= 1.1
+        end
+        mc_state.count_rot[2] = 0
+    end
+    return mc_state
+end
+    
+#    for i in 1:length(count_acc)
+#       acc_rate =  count_accept[i] / (displ.update_step * n_atom)
+#        if acc_rate < 0.4
+#            displ.max_displacement[i] *= 0.9
+#        elseif acc_rate > 0.6
+#            displ.max_displacement[i] *= 1.1
+#        end
+#        count_accept[i] = 0
+#    end
+#    return displ, count_accept
+#end
+
+#function mc_step_atom!(config, beta, dist2_mat, en_tot, i_atom, max_displacement, count_acc, count_acc_adjust, pot)
     #move randomly selected atom (obeying the boundary conditions)
-    trial_pos = atom_displacement(config.pos[i_atom], max_displacement, config.bc)
+    #trial_pos = atom_displacement(config.pos[i_atom], max_displacement, config.bc)
     #find new distances of moved atom - might not be always needed?
-    dist2_new = [distance2(trial_pos,b) for b in config.pos]
-    en_moved = energy_update(i_atom, dist2_new, pot)
+    #dist2_new = [distance2(trial_pos,b) for b in config.pos]
+    #en_moved = energy_update(i_atom, dist2_new, pot)
     #recalculate old 
-    en_unmoved = energy_update(i_atom, dist2_mat[i_atom,:], pot)
+    #en_unmoved = energy_update(i_atom, dist2_mat[i_atom,:], pot)
     #one might want to store dimer energies per atom in vector?
     #decide acceptance
-    if metropolis_condition(en_unmoved, en_moved, beta) >= rand()
-        config.pos[i_atom] = copy(trial_pos)
-        dist2_mat[i_atom,:] = copy(dist2_new)
-        dist2_mat[:,i_atom] = copy(dist2_new)
-        en_tot = en_tot - en_unmoved + en_moved
-        count_acc += 1
-        count_acc_adjust += 1
+    #if metropolis_condition(en_unmoved, en_moved, beta) >= rand()
+        #new config accepted
+    #    config.pos[i_atom] = copy(trial_pos)
+    #    dist2_mat[i_atom,:] = copy(dist2_new)
+    #    dist2_mat[:,i_atom] = copy(dist2_new)
+    #    en_tot = en_tot - en_unmoved + en_moved
+    #    count_acc += 1
+    #    count_acc_adjust += 1
+    #end 
+    #return config, entot, dist2mat, count_acc, count_acc_adjust
+#end
+
+"""
+    atom_move!(mc_state::MCState, i_atom, pot, ensemble)
+Moves selected `i_atom`'s atom randomly (max. displacement as in `mc_state`).
+Calculates energy update (depending on potential `pot`).
+Accepts move according to Metropolis criterium (asymmetric choice, depending on `ensemble`)
+Updates `mc_state` if move accepted.
+"""
+function atom_move!(mc_state::MCState, i_atom, pot, ensemble)
+    #move randomly selected atom (obeying the boundary conditions)
+    trial_pos = atom_displacement(mc_state.config.pos[i_atom], mc_state.max_displ[1], mc_state.config.bc)
+    #find new distances of moved atom 
+    delta_en, dist2_new = energy_update(trial_pos, i_atom, mc_state.config, mc_state.dist2_mat, pot)
+    #decide acceptance
+    if metropolis_condition(ensemble, delta_en, mc_state.beta) >= rand()
+        #new config accepted
+        mc_state.config.pos[i_atom] = trial_pos #copy(trial_pos)
+        mc_state.dist2_mat[i_atom,:] = dist2_new #copy(dist2_new)
+        mc_state.dist2_mat[:,i_atom] = dist2_new
+        mc_state.en_tot += delta_en
+        mc_state.count_atom[1] += 1
+        mc_state.count_atom[2] += 1
+    end
+    return mc_state #config, entot, dist2mat, count_acc, count_acc_adjust
+end
+
+"""
+    mc_step!(mc_state::MCState, pot, ensemble, a, v, r)
+Performs an individual MC step.
+Chooses type of move randomly according to frequency of moves `a`,`v` and `r` 
+for atom, volume and rotation moves.
+Performs the selected move.   
+"""
+function mc_step!(mc_state::MCState, pot, ensemble, a, v, r)
+    ran = rand(1:(a+v+r)) #choose move randomly
+    if ran <= a
+        mc_state = atom_move!(mc_state, ran, pot, ensemble)
+    #else if ran <= v
+    #    vol_move!(mc_state, pot, ensemble)
+    #else if ran <= r
+    #    rot_move!(mc_state, pot, ensemble)
+    end
+    return mc_state
+end 
+
+"""
+    mc_cycle!(mc_states, move_strat, mc_params, pot, ensemble, n_steps, a, v, r)
+Performs a MC cycle consisting of `n_steps` individual MC steps 
+(frequencies of moves given by `a`,`v` and `r`).
+Attempts parallel tempering step for 10% of cycles.
+Exchanges trajectories if exchange accepted.
+"""
+function mc_cycle!(mc_states, move_strat, mc_params, pot, ensemble, n_steps, a, v, r)
+    #perform one MC cycle
+    for i_traj = 1:mc_params.n_traj
+        for i_step = 1:n_steps
+            #mc_states[i_traj] = mc_step!(type_moves[ran][2], type_moves[ran][1], mc_states[i_traj], ran, pot, ensemble)
+            @inbounds mc_states[i_traj] = mc_step!(mc_states[i_traj], pot, ensemble, a, v, r)
+        end
+        #push!(mc_states[i_traj].ham, mc_states[i_traj].en_tot) #to build up ham vector of sampled energies
+    end
+    #parallel tempering
+    if rand() < 0.1 #attempt to exchange trajectories
+        n_exc = rand(1:mc_params.n_traj-1)
+        mc_states[n_exc].count_exc[1] += 1
+        mc_states[n_exc+1].count_exc[1] += 1
+        exc_acc = exc_acceptance(mc_states[n_exc].beta, mc_states[n_exc+1].beta, mc_states[n_exc].en_tot,  mc_states[n_exc+1].en_tot)
+        if exc_acc > rand()
+            mc_states[n_exc].count_exc[2] += 1
+            mc_states[n_exc+1].count_exc[2] += 1
+            mc_states[n_exc], mc_states[n_exc+1] = exc_trajectories!(mc_states[n_exc], mc_states[n_exc+1])
+        end
+    end
+    return mc_states
+end
+
+"""
+    ptmc_run!(mc_states, move_strat, mc_params, pot, ensemble, results)
+Main function, controlling the parallel tempering MC run.
+Calculates number of MC steps per cycle.
+Performs equilibration and main MC loop.  
+Energy is sampled after `mc_sample` MC cycles. 
+Step size adjustment is done after `n_adjust` MC cycles.    
+Evaluation: including calculation of inner energy, heat capacity, energy histograms;
+saved in `results`.
+"""
+function ptmc_run!(mc_states, move_strat, mc_params, pot, ensemble, results)
+    a = atom_move_frequency(move_strat)
+    v = vol_move_frequency(move_strat)
+    r = rot_move_frequency(move_strat)
+    #number of MC steps per MC cycle
+    n_steps = a + v + r
+
+    println("Total number of moves per MC cycle: ", n_steps)
+    println()
+
+    #equilibration cycle
+    for i = 1:mc_params.eq_cycles
+        @inbounds mc_states = mc_cycle!(mc_states, move_strat, mc_params, pot, ensemble, n_steps, a, v, r)
+        if rem(i, mc_params.n_adjust) == 0
+            for i_traj = 1:mc_params.n_traj
+                update_max_stepsize!(mc_states[i_traj], mc_params.n_adjust, a, v, r)
+            end 
+        end
+    end
+    #re-set counter variables to zero
+    for i_traj = 1:mc_params.n_traj
+        mc_states[i_traj].count_atom = [0, 0]
+        mc_states[i_traj].count_vol = [0, 0]
+        mc_states[i_traj].count_rot = [0, 0]
+        mc_states[i_traj].count_exc = [0, 0]
     end 
-    #restore or accept
-    return config, entot, dist2mat, count_acc, count_acc_adjust
+
+    println("equilibration done")
+
+    #main MC loop
+    for i = 1:mc_params.mc_cycles
+        @inbounds mc_states = mc_cycle!(mc_states, move_strat, mc_params, pot, ensemble, n_steps, a, v, r) 
+        #sampling step
+        if rem(i, mc_params.mc_sample) == 0
+            for i_traj=1:mc_params.n_traj
+                push!(mc_states[i_traj].ham, mc_states[i_traj].en_tot) #to build up ham vector of sampled energies
+            end
+        end 
+        #step adjustment
+        if rem(i, mc_params.n_adjust) == 0
+            for i_traj = 1:mc_params.n_traj
+                update_max_stepsize!(mc_states[i_traj], mc_params.n_adjust, a, v, r)
+            end 
+        end
+    end
+
+    println("MC loop done.")
+    #Evaluation
+    #average energy
+    n_sample = mc_params.mc_cycles / mc_params.mc_sample
+    en_avg = [sum(mc_states[i_traj].ham) / n_sample for i_traj in 1:mc_params.n_traj] #floor(mc_cycles/mc_sample)
+    en2_avg = [sum(mc_states[i_traj].ham .* mc_states[i_traj].ham) / n_sample for i_traj in 1:mc_params.n_traj]
+    results.en_avg = en_avg
+
+    #heat capacity
+    results.heat_cap = [(en2_avg[i]-en_avg[i]^2) * mc_states[i].beta for i in 1:mc_params.n_traj]
+
+    #acceptance statistics
+    results.count_stat_atom = [mc_states[i_traj].count_atom[1] / (mc_params.n_atoms * mc_params.mc_cycles) for i_traj in 1:mc_params.n_traj]
+    results.count_stat_exc = [mc_states[i_traj].count_exc[2] / mc_states[i_traj].count_exc[1] for i_traj in 1:mc_params.n_traj]
+
+    println(results.heat_cap)
+
+    #energy histograms
+    T = typeof(mc_states[1].ham[1])
+    en_min = T[]
+    en_max = T[]
+    for i_traj in 1:mc_params.n_traj
+        push!(en_min,minimum(mc_states[i_traj].ham))
+        push!(en_max,maximum(mc_states[i_traj].ham))
+    end 
+    global_en_min = minimum(en_min)
+    global_en_max = maximum(en_max)
+    delta_en = (global_en_max - global_en_min) / (results.n_bin - 1)
+    
+
+    for i_traj in 1:mc_params.n_traj
+        hist = EnHist(results.n_bin, global_en_min, global_en_max)
+        for en in mc_states[i_traj].ham
+            index = floor(Int,(en - global_en_min) / delta_en) + 1
+            hist.en_hist[index] += 1
+        end
+        push!(results.en_histogram, hist)
+    end
+
+    #TO DO
+    # volume (NPT ensemble),rot moves ...
+    # move boundary condition from config to mc_params?
+    # rdfs
+
+    println("done")
+    return 
 end
 
 end

--- a/src/ParallelTemperingMonteCarlo.jl
+++ b/src/ParallelTemperingMonteCarlo.jl
@@ -10,10 +10,10 @@ include("InputParams.jl")
 include("MCMoves.jl")
 include("MCRun.jl")
 
- @reexport using .InputParams
  @reexport using .BoundaryConditions
  @reexport using .Configurations
  @reexport using .EnergyEvaluation
+ @reexport using .InputParams
  #@reexport using .Initialization
  @reexport using .MCMoves
  @reexport using .MCRun

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,11 +46,8 @@ using StaticArrays, LinearAlgebra
     trial_pos = atom_displacement(v3,displ,bc)
     @test norm(trial_pos-v3) < displ
 
-    move_atom=AtomMove(10)
+    move_atom=AtomMove(10, displ)
     @test move_atom.frequency == 10
-    #pos = move_atom!(conf.pos[1],delta,bc)
-    #pos = atom_displacement(conf.pos[1], max_displacement, bc::SphericalBC)
-
 end
 
 @testset "BoundaryConditions" begin


### PR DESCRIPTION
* bug fix energy_update

* update ne13 script

* AbstractEnsemble, NVT and NPT structs

* ensemble in script, exported

* mc_step for NVT, AtomMove

* cleaned mc_step! for atom move

* export of new functions

* started ptmc_run; determine n_moves per MCcycle

* + mutable struct StatMoves

* changed stat_moves, ptmc!

* update struct AtomMove to include max_displacement

* clean up, updated test for AtomMove

* update_max_stepsize to MCMoves.jl and updated

* initialisation update

* + MCState as mutable struct

* new struct MCState; AtomMove update

* update on AtomMove struct

* update of tests for AtomMove

* +construcor for MCState

* +EnHist struct

* correction, +method for MCState

* update script

* MCStates input script

* enhist

* atomic units for coordinates

* completed script for ne13

* intro of MC loops

* correction MCState construction

* removed en_hist from MCState

* + MoveStrategy

* updated MCStates to include move counters

* +displ in MCStates

* additional constructors for MoveStrategy

* clean up

* added @inbounds in for loops

* added PT - exc_acceptance; exc_trajectories

* cosmetics

* clean up

* +struct  Report (for collecting results)

* correction

* correction Output struct

* another try

* changes to Output struct

* step_size adjustment

* trials

* evaluation - inner energy, heatcap

* more  cosmetics

* small changes

* possibility to set random seed

* clean up

* correction for calc of beta_grid

* little things

* documentation for metropolis_condition

* +docu for MCState

* more documentation

* update of Output struct

* added statistics of atom moves

* stat for exchanges

* + evaluation for en_histogram

* more documentation done

* clean-up

* more documentation

* added documentation