### PR TITLE
Feature/RuNNerCutoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Trial.jl
 scripts/*.data
 .vscode
 .DS_Store
+/scripts/tests.ipynb

--- a/scripts/cu124.jl
+++ b/scripts/cu124.jl
@@ -194,3 +194,4 @@ n_bin = 100
 bc_cu124 = SphericalBC(radius=16*AtoBohr)   #5.32 Angstrom
 start_config = Config(pos_cu124, bc_cu124)
 @time states,results = ptmc_run!(mc_params,temp,start_config,pot,ensemble;save=1000)
+


### PR DESCRIPTION
Changes to the way RuNNer is calculated to implement an inner cutoff. This is designed to compensate for the artificial minimum the potential finds at too-small distances. Also added tests.ipynb to the .gitignore because I always forget to delete this file