### PR TITLE
Feature/store_configurations

### DIFF
--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -210,8 +210,8 @@ function equilibration(mc_states::MCStateVector,move_strat::MoveStrategy{N,E},mc
     end
 end
 """
-    (ptmc_run!(mc_params::MCParams, temp::TempGrid, start_config::Config, potential::Ptype, ensemble::Etype; rdfsave = false, restart = false, save = false, workingdirectory = pwd()) where Ptype <: AbstractPotential) where Etype <: AbstractEnsemble
-    ptmc_run!(restart::Bool; rdfsave = false, save = 1000, eq_cycles = 0.2)
+    (ptmc_run!(mc_params::MCParams, temp::TempGrid, start_config::Config, potential::Ptype, ensemble::Etype; rdfsave = false, restart = false, save = false, workingdirectory = pwd(), saveconfigs=false, save_name="configuration") where Ptype <: AbstractPotential) where Etype <: AbstractEnsemble
+    ptmc_run!(restart::Bool; rdfsave = false, save = 1000, eq_cycles = 0.2, saveconfigs=false, save_name="configuration")
 
 Main call for the ptmc program. Given `mc_params` dictating the number of cycles etc. the `temps` containing the temperature and beta values we aim to simulate, an initial `start_config` and the `potential` and `ensemble` we run a complete simulation, explicitly outputting the `mc_states` and `results` structs. 
 -   Second method:
@@ -223,9 +223,11 @@ The second method relies on a series of checkpoint files -see Checkpoint module 
     -   `restart::Bool` : tells the simulation whether or not we are beginning from a partially complete simulation - set false for method one. 
     -   `acc::Vector` : sets the min and max acceptance rates used to adjust stepsize for the simulation - set [0.4 0.6] for a target of 40-60% acceptance 
     -   `save::Bool` or `Int` : tells the simulation whether to write checkpoints - set false for no save or integer expressing save frequency
+    -   `saveconfigs::Bool` or `Int` : tells the simulation whether to save configurations - set false for no save or integer expressing save frequency
+    -   `save_name::AbstractString` : tells the simulation what name to save configuration files under.
 
 """
-function ptmc_run!(mc_params::MCParams,temp::TempGrid,start_config::Config,potential::Ptype,ensemble::Etype; rdfsave = false,restart=false,save=false,workingdirectory=pwd())
+function ptmc_run!(mc_params::MCParams,temp::TempGrid,start_config::Config,potential::Ptype,ensemble::Etype; rdfsave = false, restart=false,save=false,workingdirectory=pwd(), saveconfigs=false, save_name="configuration")
     cd(workingdirectory)
     #initialise the states and results etc
     if save != false
@@ -251,6 +253,10 @@ function ptmc_run!(mc_params::MCParams,temp::TempGrid,start_config::Config,poten
         elseif rem(i,save) == 0
             checkpoint(i,mc_states,results,ensemble,rdfsave)
         end
+        if saveconfigs == false
+        elseif rem(i, saveconfigs) == 0
+            save_configs(mc_states, string(save_name, i))
+        end
     end
     println("MC loop done.")
 
@@ -260,7 +266,7 @@ function ptmc_run!(mc_params::MCParams,temp::TempGrid,start_config::Config,poten
     return mc_states,results
 end
 
-function ptmc_run!(restart::Bool;rdfsave=false,save=1000,eq_cycles=0.2)
+function ptmc_run!(restart::Bool;rdfsave=false,save=1000,eq_cycles=0.2, saveconfigs=false, save_name="configuration")
 
     mc_params,ensemble,potential,mc_states,move_strategy,results,n_steps,start_counter = initialisation(restart,eq_cycles)
     println("params set")
@@ -278,6 +284,10 @@ function ptmc_run!(restart::Bool;rdfsave=false,save=1000,eq_cycles=0.2)
         if save == false
         elseif rem(i,save) == 0
             checkpoint(i,mc_states,results,ensemble,rdfsave)
+        end
+        if saveconfigs == false
+        elseif rem(i, saveconfigs) == 0
+            save_configs(mc_states, string(save_name, i))
         end
     end
     println("MC loop done.")

--- a/src/ReadSave.jl
+++ b/src/ReadSave.jl
@@ -13,7 +13,7 @@ using ..EnergyEvaluation
 using ..MCStates
 
 
-export save_init,save_histparams,checkpoint
+export save_init,save_histparams,checkpoint,save_configs
 export read_init,setresults,rebuild_states,read_config,build_states
 #---------------------------------------------------------------#
 #-----------------------Static Parameters-----------------------#
@@ -143,12 +143,15 @@ function checkpoint_config(savefile::SaveFile, state::MCState{T,N,BC,Ptype,Etype
     end
 end
 """
-    save_configs(mc_states::MCStateVector)
-Function to save the configuration of each state in a vector of `mc_states`. Writes each configuration according to [`checkpoint_config`](@ref) into a file `config.i` where `i` indicates the order of the states. 
+    save_configs(mc_states::MCStateVector, filename::AbstractString="config")
+Function to save the configuration of each state in a vector of `mc_states`. 
+Writes each configuration according to [`checkpoint_config`](@ref) into a file `filename.i`
+where `i` indicates the order of the states.
+Default file name is "config". 
 """
-function save_configs(mc_states::MCStateVector)
+function save_configs(mc_states::MCStateVector, filename::AbstractString="config")
     for saveindex in eachindex(mc_states)
-        checkpoint_file = open("./checkpoint/config.$saveindex","w")
+        checkpoint_file = open(string("./checkpoint/", filename, "T", saveindex, ".xyz"), "w")
         checkpoint_config(checkpoint_file,mc_states[saveindex])
         # checkpoint_config(checkpoint_file,mc_states[saveindex].config, mc_states[saveindex].max_displ, mc_states[saveindex].count_atom[1],mc_states[saveindex].count_volume[1])
         close(checkpoint_file)
@@ -395,7 +398,7 @@ function rebuild_states(n_traj::Int,ensemble::AbstractEnsemble,temps::TempGrid,p
     results = setresults(dataread[2,:],histiread,ev_info,rdfinfo)
     mcstates = []
     for index in 1:n_traj
-        configfile = open("./checkpoint/config.$index","r+")
+        configfile = open("./checkpoint/configT$index.xyz","r+")
         configinfo=readdlm(configfile)
         close(configfile)
         conf,maxdisp,countatom,countvol = read_checkpoint_config(configinfo)
@@ -411,13 +414,13 @@ end
 For use initialising states and outputs when NOT restarting, but beginning from files. Builds empty [`Output`](@ref) struct named `results` and a vector of `mc_states` using either: one configuration stored in `config.data` OR a series of configurations stored in `config.i`. NB if `config.i` doesn't exist the default will be `config.1`. In this way states can be initialised with different starting configurations.  
 """
 function build_states(mc_params::MCParams,ensemble::AbstractEnsemble,temp::TempGrid,potential::AbstractPotential)
-    if ispath("./checkpoint/config.1")
+    if ispath("./checkpoint/configT1.xyz")
     confvec=[]
     for i in 1:mc_params.n_traj 
-        if ispath("./checkpoint/config.$i")
-            confinfo=readdlm("./checkpoint/config.$i")
+        if ispath("./checkpoint/configT$i.xyz")
+            confinfo=readdlm("./checkpoint/configT$i.xyz")
         else
-            confinfo=readdlm("./checkpoint/config.1")
+            confinfo=readdlm("./checkpoint/configT1.xyz")
         end
         conf=read_config(confinfo)
         push!(confvec,conf)

--- a/test/ne13.jl
+++ b/test/ne13.jl
@@ -86,7 +86,7 @@ n_adjust = 100;
 # Next we include parameters that characterise how often the configuration is saved:
 save_configuration = true
 save_frequency = 20_000
-file_name = "Configurations"
+file_name = "Temporary"
 
 # For neatness, all parameters are collected in a `MCParams` struct:
 


### PR DESCRIPTION
Implemented option to save configurations and tested this on ne_13.jl (now included in test folder). Modification of ReadSave.jl also means that all saved configuration files have .xyz file extension. Formatting change means files now saved as "$filenameT$index.xyz" (e.g. "configurationT13.xyz") instead of "$filename.$index" (e.g. "configuration.13"). Further changes inReadSave.jl are to fix errors associated with this convention change.