### PR TITLE
Saving stats to table

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,3 +10,4 @@ jobs:
       - uses: julia-actions/julia-format@v4
         with:
           version: '1' # Set `version` to '1.0.54' if you need to use JuliaFormatter.jl v1.0.54 (default: '1')
+          suggestion-label: 'format-suggest' # Leave this unset or empty to show suggestions for all PRs

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.3.5"
 authors = ["Elke Pahl <Elke.Pahl@auckland.ac.nz>"]
 
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
@@ -14,6 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 
 [compat]
+DataFrames = "1"
 DelimitedFiles = "1"
 LinearAlgebra = "1"
 ProgressMeter = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ authors = ["Elke Pahl <Elke.Pahl@auckland.ac.nz>"]
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -15,6 +16,7 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 [compat]
 DelimitedFiles = "1"
 LinearAlgebra = "1"
+ProgressMeter = "1"
 Random = "1"
 Reexport = "1"
 StaticArrays = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.3.5"
 authors = ["Elke Pahl <Elke.Pahl@auckland.ac.nz>"]
 
 [deps]
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -15,6 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 
 [compat]
+Arrow = "2"
 DataFrames = "1"
 DelimitedFiles = "1"
 LinearAlgebra = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -49,7 +49,7 @@ Generates the documentation markdown files for a (sub)module given the path of i
 function write_md(parent_module::String, module_name::String)
     fpath = joinpath(dirname(@__FILE__), "src", module_name * ".md")
     open(fpath, "w") do io
-        write(
+        return write(
             io,
             "# $module_name\n\n```@autodocs\nModules = [$parent_module.$module_name]\n```",
         )
@@ -58,7 +58,7 @@ end
 
 #Create home page
 open(joinpath(dirname(@__FILE__), "src", "index.md"), "w") do io
-    write(io, "# $main_module\n\n```@contents\n```")
+    return write(io, "# $main_module\n\n```@contents\n```")
 end
 
 #Dynamically create the documentation pages argument for makedocs.

--- a/scripts/ne13.jl
+++ b/scripts/ne13.jl
@@ -93,6 +93,6 @@ start_config = Config(pos_ne13, bc_ne13)
 
 _, results = ptmc_run!(mc_params, temp, start_config, pot, ensemble; save=1000)
 
-res = multihistogram_NVT(ensemble, temp, results, 1e-10, false; debug=false)
+res = multihistogram_NVT(ensemble, temp, results, 1e-10, false)
 
 ##

--- a/scripts/pbc32-short.jl
+++ b/scripts/pbc32-short.jl
@@ -44,7 +44,7 @@ pot = ELJPotentialEven{6}(c)
 #------------------------Move Strategy------------------------#
 #-------------------------------------------------------------#
 separated_volume = false
-ensemble = NPT(n_atoms, pressure * 2.2937122783969076e-13 / AtoBohr^2, separated_volume)
+ensemble = NPT(n_atoms, pressure * 2.2937122783969076e-13 / AtoBohr^3, separated_volume)
 move_strat = MoveStrategy(ensemble)
 
 #-------------------------------------------------------------#

--- a/scripts/pbc32-short.jl
+++ b/scripts/pbc32-short.jl
@@ -96,4 +96,4 @@ start_config = Config(positions, boundary_condition)
 #-------------------------Run Simulation-------------------------#
 #----------------------------------------------------------------#
 mc_states, results = ptmc_run!(mc_params, temp, start_config, pot, ensemble; save=1000)
-T, Cv = multihistogram_NPT(ensemble, temp, results, 1e-10, false; debug=false)
+T, Cv = multihistogram_NPT(ensemble, temp, results, 1e-10, false)

--- a/scripts/pbc32.jl
+++ b/scripts/pbc32.jl
@@ -96,4 +96,4 @@ start_config = Config(positions, boundary_condition)
 #-------------------------Run Simulation-------------------------#
 #----------------------------------------------------------------#
 mc_states, results = ptmc_run!(mc_params, temp, start_config, pot, ensemble; save=1000)
-T, Cv = multihistogram_NPT(ensemble, temp, results, 1e-10, false; debug=false)
+T, Cv = multihistogram_NPT(ensemble, temp, results, 1e-10, false)

--- a/scripts/pbc32.jl
+++ b/scripts/pbc32.jl
@@ -17,7 +17,7 @@ n_traj = 24
 temp = TempGrid{n_traj}(ti, tf)
 
 # MC simulation details
-mc_cycles = 1_000_000 # default 20% equilibration cycles on top
+mc_cycles = 1_00_000 # default 20% equilibration cycles on top
 mc_sample = 1        # sample every mc_sample MC cycles
 displ_atom = 0.05    # in Angstrom
 n_adjust = 100
@@ -44,7 +44,7 @@ pot = ELJPotentialEven{6}(c)
 #------------------------Move Strategy------------------------#
 #-------------------------------------------------------------#
 separated_volume = false
-ensemble = NPT(n_atoms, pressure * 2.2937122783969076e-13 / AtoBohr^2, separated_volume)
+ensemble = NPT(n_atoms, pressure * 2.2937122783969076e-13 / AtoBohr^3, separated_volume)
 move_strat = MoveStrategy(ensemble)
 
 #-------------------------------------------------------------#

--- a/scripts/pbc32.jl
+++ b/scripts/pbc32.jl
@@ -17,7 +17,7 @@ n_traj = 24
 temp = TempGrid{n_traj}(ti, tf)
 
 # MC simulation details
-mc_cycles = 1_000_000 # default 20% equilibration cycles on top
+mc_cycles = 100_000 # default 20% equilibration cycles on top
 mc_sample = 1        # sample every mc_sample MC cycles
 displ_atom = 0.05    # in Angstrom
 n_adjust = 100
@@ -44,7 +44,7 @@ pot = ELJPotentialEven{6}(c)
 #------------------------Move Strategy------------------------#
 #-------------------------------------------------------------#
 separated_volume = false
-ensemble = NPT(n_atoms, pressure * 2.2937122783969076e-13 / AtoBohr^2, separated_volume)
+ensemble = NPT(n_atoms, pressure * 2.2937122783969076e-13 / AtoBohr^3, separated_volume)
 move_strat = MoveStrategy(ensemble)
 
 #-------------------------------------------------------------#

--- a/scripts/pbc32.jl
+++ b/scripts/pbc32.jl
@@ -17,7 +17,7 @@ n_traj = 24
 temp = TempGrid{n_traj}(ti, tf)
 
 # MC simulation details
-mc_cycles = 1_00_000 # default 20% equilibration cycles on top
+mc_cycles = 10_000 # default 20% equilibration cycles on top
 mc_sample = 1        # sample every mc_sample MC cycles
 displ_atom = 0.05    # in Angstrom
 n_adjust = 100
@@ -95,5 +95,7 @@ start_config = Config(positions, boundary_condition)
 #----------------------------------------------------------------#
 #-------------------------Run Simulation-------------------------#
 #----------------------------------------------------------------#
-mc_states, results = ptmc_run!(mc_params, temp, start_config, pot, ensemble; save=1000)
-T, Cv = multihistogram_NPT(ensemble, temp, results, 1e-10, false)
+mc_states, results, stats = ptmc_run!(
+    mc_params, temp, start_config, pot, ensemble; save=1000
+)
+#T, Cv = multihistogram_NPT(ensemble, temp, results, 1e-10, false)

--- a/src/BoundaryConditions.jl
+++ b/src/BoundaryConditions.jl
@@ -10,6 +10,7 @@ using StaticArrays
 
 export SphericalBC, AbstractBC, PeriodicBC, CubicBC, RhombicBC, RectangularBC
 export check_boundary, long_range_correction, volume, r_cut
+export report_stats
 
 """
     AbstractBC{T}
@@ -112,6 +113,13 @@ Scale boundary condition, vector, or configuration in the ``z`` dimension by fac
 scale_z
 
 """
+    report_stats(::AbstractBC)
+
+Report information about boundary condition to output.
+"""
+report_stats
+
+"""
     SphericalBC{T}(;radius::Real)
 
 Implements type for spherical boundary conditions; subtype of [`AbstractBC`](@ref).
@@ -134,6 +142,8 @@ function check_boundary(bc::SphericalBC, position)
         return position
     end
 end
+
+report_stats(bc::SphericalBC) = (; radius=√bc.radius2)
 
 """
     PeriodicBC{T}
@@ -184,6 +194,8 @@ scale_xyz(bc::CubicBC, α) = CubicBC(α * bc.box_length)
 
 r_cut(bc::CubicBC) = bc.box_length^2 / 4
 
+report_stats(bc::CubicBC) = (; box_length=bc.box_length)
+
 """
     RectangularBC{T}
 
@@ -219,6 +231,8 @@ scale_xy(bc::RectangularBC, scale) = RectangularBC(bc.box_length * scale, bc.box
 scale_z(bc::RectangularBC, scale) = RectangularBC(bc.box_length, bc.box_height * scale)
 
 r_cut(bc::RectangularBC) = min(bc.box_length^2 / 4, bc.box_height^2 / 4)
+
+report_stats(bc::RectangularBC) = (; box_length=bc.box_length, box_height=bc.box_height)
 
 """
     RhombicBC{T}(; length::Real, height::Real)
@@ -266,5 +280,7 @@ scale_xy(bc::RhombicBC, scale) = RhombicBC(bc.box_length * scale, bc.box_height)
 scale_z(bc::RhombicBC, scale) = RhombicBC(bc.box_length, bc.box_height * scale)
 
 r_cut(bc::RhombicBC) = min(bc.box_length^2 * 3 / 16, bc.box_height^2 / 4)
+
+report_stats(bc::RhombicBC) = (; box_length=bc.box_length, box_height=bc.box_height)
 
 end

--- a/src/BoundaryConditions.jl
+++ b/src/BoundaryConditions.jl
@@ -81,7 +81,7 @@ r_cut(::AbstractBC) = Inf
 Returns the volume of a box according to its geometry for use where the ensemble does not
 imply a fixed `V`.
 """
-volume
+volume(::AbstractBC) = missing # TODO: avoid computing volume for non NPT ensembles
 
 """
     scale_xyz(::AbstractBC, α)

--- a/src/BoundaryConditions.jl
+++ b/src/BoundaryConditions.jl
@@ -81,7 +81,7 @@ r_cut(::AbstractBC) = Inf
 Returns the volume of a box according to its geometry for use where the ensemble does not
 imply a fixed `V`.
 """
-volume(::AbstractBC) = missing # TODO: avoid computing volume for non NPT ensembles
+volume
 
 """
     scale_xyz(::AbstractBC, α)

--- a/src/BoundaryConditions.jl
+++ b/src/BoundaryConditions.jl
@@ -81,7 +81,7 @@ r_cut(::AbstractBC) = Inf
 Returns the volume of a box according to its geometry for use where the ensemble does not
 imply a fixed `V`.
 """
-volume
+volume(::AbstractBC) = missing
 
 """
     scale_xyz(::AbstractBC, α)

--- a/src/Configurations.jl
+++ b/src/Configurations.jl
@@ -242,7 +242,7 @@ function scale_xyz(config::Config, α)
 end
 function scale_xy(pos, scale)
     new_pos = map(pos) do p
-        SVector(p[1] * scale, p[2] * scale, p[3])
+        return SVector(p[1] * scale, p[2] * scale, p[3])
     end
     return new_pos
 end
@@ -253,7 +253,7 @@ function scale_xy(config::Config, scale)
 end
 function scale_z(pos, scale)
     new_pos = map(pos) do p
-        SVector(p[1], p[2], p[3] * scale)
+        return SVector(p[1], p[2], p[3] * scale)
     end
     return new_pos
 end

--- a/src/Ensembles.jl
+++ b/src/Ensembles.jl
@@ -2,6 +2,7 @@ module Ensembles
 
 using ..Configurations
 using ..BoundaryConditions
+import ..BoundaryConditions: report_stats
 using StaticArrays, Random
 
 export AbstractEnsemble, NVT, NPT, NNVT
@@ -93,7 +94,8 @@ function NPT(n_atoms, pressure, separated_volume)
 end
 
 function report_stats(mc_state, ::NPT)
-    return (; volume=volume(mc_state.config.boundary_condition), length_height_ratio=mc_state.lh_ratio)
+    bc = mc_state.config.boundary_condition
+    return (; volume=volume(bc), report_stats(bc)...)
 end
 
 """

--- a/src/Ensembles.jl
+++ b/src/Ensembles.jl
@@ -9,7 +9,7 @@ export AbstractEnsemble, NVT, NPT, NNVT
 export AbstractEnsembleVariables,
     NVTVariables, NPTVariables, NNVTVariables, set_ensemble_variables
 
-export MoveType, atommove, volumemove, atomswap
+export MoveType, atommove, volumemove, atomswap, report_stats
 export MoveStrategy
 
 """
@@ -21,6 +21,16 @@ Abstract type for ensemble:
 Each subtype requires a corresponding [`AbstractEnsembleVariables`](@ref) struct.
 """
 abstract type AbstractEnsemble end
+
+"""
+    report_stats(mc_state, ensemble)
+
+Return a `NamedTuple` of statistics to report in the result table. The default
+implementation used by [`NVT`](@ref), [`NNVT`](@ref) returns an empty `NamedTuple`.
+"""
+function report_stats(_, ::AbstractEnsemble)
+    return NamedTuple()
+end
 
 """
     AbstractEnsembleVariables
@@ -80,6 +90,10 @@ end
 
 function NPT(n_atoms, pressure, separated_volume)
     return NPT(n_atoms, n_atoms, 1, 0, pressure, separated_volume)
+end
+
+function report_stats(mc_state, ::NPT)
+    return (; volume=volume(mc_state.config.boundary_condition), LH_ratio=mc_state.lh_ratio)
 end
 
 """

--- a/src/Ensembles.jl
+++ b/src/Ensembles.jl
@@ -7,7 +7,7 @@ using StaticArrays, Random
 export AbstractEnsemble, NVT, NPT, NNVT
 
 export AbstractEnsembleVariables,
-    NVTVariables, NPTVariables, NNVTVariables, set_ensemble_variables
+    NVTVariables, NPTVariables, NNVTVariables, set_ensemble_variables, hamiltonian
 
 export MoveType, atommove, volumemove, atomswap
 export MoveStrategy
@@ -151,6 +151,10 @@ end
 #---------------------------------------------------------------------#
 #------------------------global functions-----------------------------#
 #---------------------------------------------------------------------#
+function hamiltonian(state, ::AbstractEnsemble)
+    return state.en_tot
+end
+
 """
     set_ensemble_variables(config::Config, ensemble::NVT)
     set_ensemble_variables(config::Config, ensemble::NPT)
@@ -180,6 +184,10 @@ function set_ensemble_variables(config::Config{T}, ensemble::NNVT) where {T}
     return NNVTVariables{T,length(config),N1,N2}(
         1, SVector{3}(zeros(3)), SVector{2}(1, N1 + 1)
     )
+end
+
+function hamiltonian(state, ensemble::NPT)
+    return state.en_tot + ensemble.pressure * volume(state.config.boundary_condition)
 end
 
 """

--- a/src/Ensembles.jl
+++ b/src/Ensembles.jl
@@ -93,7 +93,7 @@ function NPT(n_atoms, pressure, separated_volume)
 end
 
 function report_stats(mc_state, ::NPT)
-    return (; volume=volume(mc_state.config.boundary_condition), LH_ratio=mc_state.lh_ratio)
+    return (; volume=volume(mc_state.config.boundary_condition), length_height_ratio=mc_state.lh_ratio)
 end
 
 """

--- a/src/Exchange.jl
+++ b/src/Exchange.jl
@@ -154,12 +154,13 @@ function parallel_tempering_exchange!(
     mc_states[n_exc].count_exc[1] += 1
     mc_states[n_exc + 1].count_exc[1] += 1
 
-    success = rand() < exc_acceptance(
-        mc_states[n_exc].beta,
-        mc_states[n_exc + 1].beta,
-        hamiltonian(mc_states[n_exc], ensemble),
-        hamiltonian(mc_states[n_exc + 1], ensemble),
-    )
+    success =
+        rand() < exc_acceptance(
+            mc_states[n_exc].beta,
+            mc_states[n_exc + 1].beta,
+            hamiltonian(mc_states[n_exc], ensemble),
+            hamiltonian(mc_states[n_exc + 1], ensemble),
+        )
 
     if success
         mc_states[n_exc].count_exc[2] += 1

--- a/src/Exchange.jl
+++ b/src/Exchange.jl
@@ -147,7 +147,7 @@ These functions take a vector `mc_states` as well as the parameters of the simul
 The second method uses enthalpy instead of energy to determine acceptance.
 """
 function parallel_tempering_exchange!(
-    mc_states::MCStateVector, mc_params::MCParams, ensemble::AbstractEnsemble
+    mc_states, mc_params::MCParams, ensemble::AbstractEnsemble
 )
     n_exc = rand(1:(mc_params.n_traj - 1))
 
@@ -171,7 +171,7 @@ function parallel_tempering_exchange!(
     return mc_states
 end
 function parallel_tempering_exchange!(
-    mc_states::MCStateVector, mc_params::MCParams, ensemble::NPT
+    mc_states, mc_params::MCParams, ensemble::NPT
 )
     n_exc = rand(1:(mc_params.n_traj - 1))
 

--- a/src/Exchange.jl
+++ b/src/Exchange.jl
@@ -154,50 +154,24 @@ function parallel_tempering_exchange!(
     mc_states[n_exc].count_exc[1] += 1
     mc_states[n_exc + 1].count_exc[1] += 1
 
-    if exc_acceptance(
+    success = rand() < exc_acceptance(
         mc_states[n_exc].beta,
         mc_states[n_exc + 1].beta,
-        mc_states[n_exc].en_tot,
-        mc_states[n_exc + 1].en_tot,
-    ) > rand()
+        hamiltonian(mc_states[n_exc], ensemble),
+        hamiltonian(mc_states[n_exc + 1], ensemble),
+    )
+
+    if success
         mc_states[n_exc].count_exc[2] += 1
         mc_states[n_exc + 1].count_exc[2] += 1
 
         mc_states[n_exc], mc_states[n_exc + 1] = exc_trajectories!(
             mc_states[n_exc], mc_states[n_exc + 1]
         )
+        return n_exc
+    else
+        return 0
     end
-
-    return mc_states
-end
-function parallel_tempering_exchange!(mc_states, mc_params::MCParams, ensemble::NPT)
-    n_exc = rand(1:(mc_params.n_traj - 1))
-
-    mc_states[n_exc].count_exc[1] += 1
-    mc_states[n_exc + 1].count_exc[1] += 1
-
-    #if exc_acceptance(mc_states[n_exc].beta, mc_states[n_exc+1].beta, (mc_states[n_exc].en_tot + ensemble.pressure * mc_states[n_exc].config.boundary_condition.box_length^3),  (mc_states[n_exc+1].en_tot + ensemble.pressure * mc_states[n_exc+1].config.boundary_condition.box_length^3)) > rand()
-    if exc_acceptance(
-        mc_states[n_exc].beta,
-        mc_states[n_exc + 1].beta,
-        (
-            mc_states[n_exc].en_tot +
-            ensemble.pressure * volume(mc_states[n_exc].config.boundary_condition)
-        ),
-        (
-            mc_states[n_exc + 1].en_tot +
-            ensemble.pressure * volume(mc_states[n_exc + 1].config.boundary_condition)
-        ),
-    ) > rand()
-        mc_states[n_exc].count_exc[2] += 1
-        mc_states[n_exc + 1].count_exc[2] += 1
-
-        mc_states[n_exc], mc_states[n_exc + 1] = exc_trajectories!(
-            mc_states[n_exc], mc_states[n_exc + 1]
-        )
-    end
-
-    return mc_states
 end
 
 """

--- a/src/Exchange.jl
+++ b/src/Exchange.jl
@@ -170,9 +170,7 @@ function parallel_tempering_exchange!(
 
     return mc_states
 end
-function parallel_tempering_exchange!(
-    mc_states, mc_params::MCParams, ensemble::NPT
-)
+function parallel_tempering_exchange!(mc_states, mc_params::MCParams, ensemble::NPT)
     n_exc = rand(1:(mc_params.n_traj - 1))
 
     mc_states[n_exc].count_exc[1] += 1

--- a/src/Initialization.jl
+++ b/src/Initialization.jl
@@ -64,7 +64,7 @@ function initialisation(
 )
     move_strategy = MoveStrategy(ensemble)
     mc_states = map(1:(mc_params.n_traj)) do i
-        MCState(
+        return MCState(
             temp.t_grid[i],
             start_config[mod1(i, length(start_config))],
             ensemble,

--- a/src/Initialization.jl
+++ b/src/Initialization.jl
@@ -17,8 +17,9 @@ using ..ReadSave
 using ..Ensembles
 
 """
-    initialisation(mc_params::MCParams,temp::TempGrid,start_config::Config,potential,ensemble::NVT)
-    initialisation(restart::Bool;eq_cycles::Number)
+    initialisation(mc_params, temp, start_config, potential, ensemble)
+    initialisation(restart::Bool; eq_cycles)
+
 Basic function for establishing the structs and parameters required for the simulation. Inputs for method one are:
 -   `mc_params`: the basic values and parameters concerning how long our simulation runs.
 -   `temp`: a grid of temp and beta values passed to the mc_states struct.
@@ -45,28 +46,6 @@ Method two also returns:
 -   consider shuffling `mc_params` to include the `tempgrid` and cut down the number of inputs.
 
 """
-#function initialisation(mc_params::MCParams,temp::TempGrid,start_config::Config,potential,ensemble)
-
-#move_strategy = MoveStrategy(ensemble)
-#n_steps = length(move_strategy)
-
-#mc_states = Array{MCState}(undef, mc_params.n_traj)
-#for i in 1:mc_params.n_traj
-#if rem(i,2) == 0
-#mc_states[i] = MCState(temp.t_grid[i], temp.beta_grid[i],start_config[1],ensemble,potential)
-#else
-#mc_states[i] = MCState(temp.t_grid[i], temp.beta_grid[i],start_config[2],ensemble,potential)
-#end
-#end
-#mc_states = [MCState(temp.t_grid[i], temp.beta_grid[i],start_config,ensemble,potential) for i in 1:mc_params.n_traj]
-
-#println(mc_states[1].en_tot)
-
-#results = Output{Float64}(mc_params.n_bin;en_min = mc_states[1].en_tot)
-#start_counter=1
-#return mc_states,move_strategy,results,n_steps,start_counter
-#end
-
 function initialisation(
     mc_params::MCParams,
     temp::TempGrid,
@@ -87,7 +66,6 @@ function initialisation(
     mc_states = map(1:(mc_params.n_traj)) do i
         MCState(
             temp.t_grid[i],
-            temp.beta_grid[i],
             start_config[mod1(i, length(start_config))],
             ensemble,
             potential,

--- a/src/InputParams.jl
+++ b/src/InputParams.jl
@@ -130,7 +130,6 @@ mutable struct Output{T}
     count_stat_vol::Vector{T}
     count_stat_rot::Vector{T}
     count_stat_exc::Vector{T}
-    stats::Vector{NamedTuple}
 end
 
 function Output{T}(n_bin::Int) where {T<:Number}
@@ -172,7 +171,6 @@ function Output{T}(n_bin::Int) where {T<:Number}
         count_stat_vol,
         count_stat_rot,
         count_stat_exc,
-        NamedTuple[],
     )
 end
 

--- a/src/InputParams.jl
+++ b/src/InputParams.jl
@@ -130,6 +130,7 @@ mutable struct Output{T}
     count_stat_vol::Vector{T}
     count_stat_rot::Vector{T}
     count_stat_exc::Vector{T}
+    stats::Vector{NamedTuple}
 end
 
 function Output{T}(n_bin::Int) where {T<:Number}
@@ -171,6 +172,7 @@ function Output{T}(n_bin::Int) where {T<:Number}
         count_stat_vol,
         count_stat_rot,
         count_stat_exc,
+        NamedTuple[],
     )
 end
 

--- a/src/MCMoves.jl
+++ b/src/MCMoves.jl
@@ -242,13 +242,13 @@ end
 [`generate_move!`](@ref) is the currying function that takes `mc_state` and a `movetype`
 and generates the variables required inside of the `ensemblevariables` struct within `mc_state`.
 """
-function generate_move!(mc_state::MCState, movetype::String, ensemble)
+function generate_move!(mc_state::MCState, movetype::String)
     if movetype == "atommove"
         return atom_displacement(mc_state)
     elseif movetype == "atomswap"
         return swap_atoms(mc_state)
     else
-        return volume_change(mc_state, ensemble.separated_volume)
+        return volume_change(mc_state, mc_state.ensemble.separated_volume)
     end
 end
 

--- a/src/MCMoves.jl
+++ b/src/MCMoves.jl
@@ -229,8 +229,8 @@ end
 Swaps two atoms in the configuration.
 """
 function swap_atoms(
-    mc_state::MCState{T,BC,PV,EV}
-) where {T,BC,PV,EV<:NNVTVariables{tee,n,N1,N2}} where {tee,n,N1,N2}
+    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,<:NNVTVariables{<:Any,<:Any,N1,N2}}
+) where {N1,N2}
     # TODO: make extracting Ns nicer than this.
     i1, i2 = rand(1:N1), rand((N1 + 1):length(mc_state.config))
     mc_state.ensemble_variables.swap_indices = SVector{2}(i1, i2)

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -397,7 +397,6 @@ function ptmc_run!(
         save_histparams(results)
     end
 
-
     # Main loop
     progress = Progress(length(start_counter:(mc_params.mc_cycles)); desc="Main loop")
     for i in start_counter:(mc_params.mc_cycles)

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -281,7 +281,7 @@ function equilibration_cycle!(
     ebounds = [100.0, -100.0]
     # Don't touch ebound for the first half of the run in case energies
     # are very high at the beginning.
-    progress = Progress(mc_params.eq_cycles; desc="Equilibration")
+    progress = Progress(mc_params.eq_cycles; desc="Equilibration", enabled=isinteractive())
     for i in 1:(mc_params.eq_cycles ÷ 2)
         mc_cycle!(mc_states, move_strat, mc_params, n_steps, i, stats)
         next!(progress)
@@ -398,7 +398,10 @@ function ptmc_run!(
     end
 
     # Main loop
-    progress = Progress(length(start_counter:(mc_params.mc_cycles)); desc="Main loop")
+    progress = Progress(
+        length(start_counter:(mc_params.mc_cycles));
+        desc="Main loop", enabled=isinteractive(),
+    )
     for i in start_counter:(mc_params.mc_cycles)
         mc_cycle!(
             mc_states,

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -418,7 +418,6 @@ function ptmc_run!(
             save_configs(mc_states, string(configsname, i))
         end
         if !isnothing(stats_filename) && i % flush_interval == 0
-            @info "Flushing data to disk"
             Arrow.append(stats_filename, stats)
             empty!(stats)
         end
@@ -431,11 +430,11 @@ function ptmc_run!(
     end
     if !isnothing(stats_filename) && flush_interval < mc_params.mc_cycles
         # write as regular file
-        Arrow.write(stats_filename, stats)
+        Arrow.append(stats_filename, stats)
         stats = DataFrame(Arrow.Table(stats_filename))
     elseif !isnothing(stats_filename)
         # append remaining rows
-        Arrow.append(stats_filename, stats)
+        Arrow.write(stats_filename, stats)
         stats = DataFrame(Arrow.Table(stats_filename))
     end
 

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -147,7 +147,7 @@ end
 Distributes each state in `mc_state` to the [`mc_move!`](@ref) function in accordance with a `move_strat`, `ensemble` and `pot`.
 """
 function mc_step!(
-    mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int
+    mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int, stats
 ) where {N,E}
     Threads.@threads for state in mc_states
         n_accepted = 0
@@ -156,7 +156,26 @@ function mc_step!(
             n_accepted += mc_move!(state, move_strat)
         end
 
+        state.step += 1
         state.acceptance = n_accepted / n_steps
+        state.last_stats = (
+            ;
+            step=state.step,
+            T=state.temp,
+            hamiltonian=hamiltonian_value(state, state.ensemble),
+            E_tot=state.en_tot,
+            acceptance=state.acceptance,
+            report_stats(state, state.ensemble)...,
+            count_atom=state.count_atom[1],
+            count_vol=state.count_vol[1],
+            count_vol_xy=state.count_vol_xy[1],
+            count_vol_z=state.count_vol_z[1],
+            count_exc=state.count_exc[1],
+        )
+
+    end
+    for state in mc_states
+        push!(stats, state.last_stats)
     end
     return mc_states
 end
@@ -175,8 +194,9 @@ function mc_cycle!(
     mc_params::MCParams,
     n_steps::Int,
     index::Int,
+    stats,
 ) where {N,E}
-    mc_step!(mc_states, move_strat, n_steps)
+    mc_step!(mc_states, move_strat, n_steps, stats)
     ensemble = mc_states[1].ensemble
 
     if rand() < 0.1
@@ -200,31 +220,15 @@ function mc_cycle!(
     idx::Int,
     rdfsave::Bool,
     potential,
+    stats,
 ) where {N,E}
     #TODO: Implement saving configurations after n steps
 
-    mc_cycle!(mc_states, move_strat, mc_params, n_steps, idx)
+    mc_cycle!(mc_states, move_strat, mc_params, n_steps, idx, stats)
     ensemble = mc_states[1].ensemble
 
     if rem(idx, mc_params.mc_sample) == 0
         sampling_step!(mc_params, mc_states, ensemble, idx, results, rdfsave, idx)
-    end
-    for state in mc_states
-        push!(state.stats,
-              (;
-               T=state.temp,
-               hamiltonian=hamiltonian_value(state, ensemble),
-               E_tot=state.en_tot,
-               acceptance=state.acceptance,
-               volume=volume(state.config.boundary_condition),
-               LH_ratio=state.lh_ratio,
-               count_atom=state.count_atom[1],
-               count_vol=state.count_vol[1],
-               count_vol_xy=state.count_vol_xy[1],
-               count_vol_z=state.count_vol_z[1],
-               count_exc=state.count_exc[1],
-               )
-              )
     end
 
     return mc_states
@@ -271,6 +275,7 @@ function equilibration_cycle!(
     mc_params::MCParams,
     n_steps::Int,
     results::Output,
+    stats,
 ) where {N,E}
 
     ebounds = [100.0, -100.0]
@@ -278,7 +283,7 @@ function equilibration_cycle!(
     # are very high at the beginning.
     progress = Progress(mc_params.eq_cycles; desc="Equilibration")
     for i in 1:(mc_params.eq_cycles ÷ 2)
-        mc_cycle!(mc_states, move_strat, mc_params, n_steps, i)
+        mc_cycle!(mc_states, move_strat, mc_params, n_steps, i, stats)
         next!(progress)
     end
     for i in (mc_params.eq_cycles ÷ 2 + 1):(mc_params.eq_cycles)
@@ -313,6 +318,7 @@ function equilibration(
     n_steps::Int,
     results::Output,
     restart::Bool,
+    stats,
 ) where {N,E}
     for state in mc_states
         push!(state.ham, 0)
@@ -323,7 +329,7 @@ function equilibration(
         return mc_states, results
     else
         return equilibration_cycle!(
-            mc_states, move_strat, mc_params, n_steps, results
+            mc_states, move_strat, mc_params, n_steps, results, stats
         )
     end
 end
@@ -363,6 +369,7 @@ function ptmc_run!(
     if save ≢ false
         save_init(potential, ensemble, mc_params, temp)
     end
+    stats = NamedTuple[]
 
     mc_states, move_strategy, results, n_steps, start_counter = initialisation(
         mc_params, temp, start_config, potential, ensemble
@@ -370,7 +377,7 @@ function ptmc_run!(
 
     # Equilibration
     mc_states, results = equilibration(
-        mc_states, move_strategy, mc_params, n_steps, results, restart
+        mc_states, move_strategy, mc_params, n_steps, results, restart, stats
     )
     if save ≢ false
         save_histparams(results)
@@ -388,6 +395,7 @@ function ptmc_run!(
             i,
             rdfsave,
             potential,
+            stats,
         )
         if save ≢ false && rem(i, save) == 0
             checkpoint(i, mc_states, results, ensemble, rdfsave)
@@ -405,7 +413,7 @@ function ptmc_run!(
 
     #Finalisation of results
     results = finalise_results(mc_states, mc_params, results)
-    return mc_states, results
+    return mc_states, results, stats
 end
 
 # This method is used to resume a saved computation
@@ -420,9 +428,10 @@ function ptmc_run!(
     mc_params, ensemble, potential, mc_states, move_strategy, results, n_steps, start_counter = initialisation(
         restart, eq_cycles
     )
+    stats = NamedTuple[]
 
     mc_states, results = equilibration(
-        mc_states, move_strategy, mc_params, n_steps, results, restart
+        mc_states, move_strategy, mc_params, n_steps, results, restart, stats
     )
     @info "equilibration complete"
 
@@ -439,7 +448,7 @@ function ptmc_run!(
             results,
             i,
             rdfsave,
-            potential,
+            stats,
         )
         if save ≢ false && rem(i, save) == 0
             checkpoint(i, mc_states, results, ensemble, rdfsave)
@@ -452,7 +461,7 @@ function ptmc_run!(
 
     results = finalise_results(mc_states, mc_params, results)
 
-    return mc_states, results
+    return mc_states, results, stats
 end
 #---------------------------------------------------------#
 #-------------Notes for Future Implementation-------------#

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -5,7 +5,7 @@ export exc_acceptance, exc_trajectories!
 export acc_test!, check_e_bounds, reset_counters, equilibration_cycle!, equilibration
 export mc_move!
 
-using StaticArrays, DelimitedFiles
+using StaticArrays, DelimitedFiles, ProgressMeter
 using ..MCStates
 using ..BoundaryConditions
 using ..Configurations
@@ -272,18 +272,21 @@ function equilibration_cycle!(
     n_steps::Int,
     results::Output,
 ) where {N,E}
-    #set initial hamiltonian values and ebounds
 
     ebounds = [100.0, -100.0]
     # Don't touch ebound for the first half of the run in case energies
     # are very high at the beginning.
+    progress = Progress(mc_params.eq_cycles; desc="Equilibration")
     for i in 1:(mc_params.eq_cycles ÷ 2)
-        mc_states = mc_cycle!(mc_states, move_strat, mc_params, n_steps, i)
+        mc_cycle!(mc_states, move_strat, mc_params, n_steps, i)
+        next!(progress)
     end
     for i in (mc_params.eq_cycles ÷ 2 + 1):(mc_params.eq_cycles)
+        #TODO: why doesn't it do anything here? Should be doing equilibration steps here as well?
         for state in mc_states
             ebounds = check_e_bounds(state.en_tot, ebounds)
         end
+        next!(progress)
     end
     #post equilibration reset
     for state in mc_states
@@ -373,9 +376,8 @@ function ptmc_run!(
         save_histparams(results)
     end
 
-    @info "equilibration complete"
-
     # Main loop
+    progress = Progress(length(start_counter:(mc_params.mc_cycles)); desc="Main loop")
     for i in start_counter:(mc_params.mc_cycles)
         mc_cycle!(
             mc_states,
@@ -393,13 +395,8 @@ function ptmc_run!(
         if saveconfigs ≢ false && rem(i, saveconfigs) == 0
             save_configs(mc_states, string(configsname, i))
         end
-        if rem(i, 100000) == 0 #TODO: this should be a progress bar
-            @info "$i"
-            #results = finalise_results_convergence(i,mc_states,mc_params,results)
-            #println(results.heat_cap)
-        end
+        next!(progress)
     end
-    @info "MC loop done."
 
     if save ≢ false && rem(mc_params.mc_cycles, save) ≠ 0
         # Save at the end if we didn't save in the last step.

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -5,7 +5,7 @@ export exc_acceptance, exc_trajectories!
 export acc_test!, check_e_bounds, reset_counters, equilibration_cycle!, equilibration
 export mc_move!
 
-using StaticArrays, DelimitedFiles, ProgressMeter
+using StaticArrays, DelimitedFiles, ProgressMeter, DataFrames
 using ..MCStates
 using ..BoundaryConditions
 using ..Configurations
@@ -367,7 +367,7 @@ function ptmc_run!(
     if save ≢ false
         save_init(potential, ensemble, mc_params, temp)
     end
-    stats = NamedTuple[]
+    stats = DataFrame()
 
     mc_states, move_strategy, results, n_steps, start_counter = initialisation(
         mc_params, temp, start_config, potential, ensemble

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -116,7 +116,7 @@ function acc_test!(mc_state::MCState, movetype::String)
     end
 end
 """
-    mc_move!(mc_state::MCState,move_strat::MoveStrategy)
+    mc_move!(mc_state::MCState, move_strat::MoveStrategy)
 
 Basic move for one `mc_state` according to a `move_strat` dictating the types of moves allowed within the `ensemble` when moving across a `potential` defining the PES.
 -   Calculates an index for the move
@@ -139,9 +139,10 @@ function mc_move!(mc_state::MCState, move_strat::MoveStrategy{N,E}) where {N,E}
 end
 
 """
-    mc_step!(mc_states, move_strat::MoveStrategy{N, E}, pot, ensemble, n_steps::Int) where {N, E}
+    mc_step!(mc_states, move_strat::MoveStrategy, n_steps)
 
-Distributes each state in `mc_state` to the [`mc_move!`](@ref) function in accordance with a `move_strat`, `ensemble` and `pot`.
+Distributes each state in `mc_state` to the [`mc_move!`](@ref) function in accordance with a
+`move_strat`.
 """
 function mc_step!(mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int, stats) where {N,E}
     Threads.@threads for state in mc_states
@@ -174,10 +175,10 @@ function mc_step!(mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int, stats)
 end
 
 """
-    mc_cycle!(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, index::Int) where {N, E}
-    mc_cycle!(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, results::Output, idx::Int, rdfsave::Bool) where {N, E}
+    mc_cycle!(mc_states, move_strat::MoveStrategy, mc_params::MCParams, n_steps, index)
+    mc_cycle!(mc_states, move_strat, mc_params, pot, ensemble, n_steps, results, idx, rdfsave)
 
-Basic function utilised by the simulation. For each of the `n_steps` run a single [`mc_step!`](@ref) on the `mc_states` according to `pot`, `move_strat` and `ensemble`, then complete the [`parallel_tempering_exchange!`](@ref) and `update_step_size!`.
+Basic function utilised by the simulation. For each of the `n_steps` run a single [`mc_step!`](@ref) on the `mc_states` according to `move_strat`, then complete the [`parallel_tempering_exchange!`](@ref) and `update_step_size!`.
 
 Second method includes the [`sampling_step!`](@ref) which updates the `results` struct. The first method is used by the [`equilibration_cycle!`](@ref) and therefore does __not__ update the results struct.
 """
@@ -235,7 +236,7 @@ function hamiltonian_value(state::MCState, ensemble::NPT)
 end
 
 """
-    check_e_bounds(energy::Number, ebounds::VorS)
+    check_e_bounds(energy, ebounds)
 Function to determine if an energy value is greater than or less than the min/max, used in equilibration cycle.
 """
 function check_e_bounds(energy::Number, ebounds::VorS)
@@ -259,8 +260,12 @@ function reset_counters(state::MCState)
 end
 
 """
-    equilibration_cycle!(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, n_steps::Int, results::Output) where {N, E}
-Function to thermalise a set of `mc_states` ensuring that the number of equilibration cycles defined in `mc_params` are completed without updating the results before initialising the `results` struct according to the maximum and minimum energy determined throughout the equilibration cycle.
+    equilibration_cycle!(mc_states, move_strat::MoveStrategy, mc_params::MCParams, n_steps, results::Output, stats)
+
+Function to thermalise a set of `mc_states` ensuring that the number of equilibration cycles
+defined in `mc_params` are completed without updating the results before initialising the
+`results` struct according to the maximum and minimum energy determined throughout the
+equilibration cycle.
 """
 function equilibration_cycle!(
     mc_states,
@@ -298,7 +303,8 @@ end
 
 #TODO: why is restart not functional?
 """
-    equilibration(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, results::Output, restart::Bool) where {N, E}
+    equilibration(mc_states, move_strat::MoveStrategy, mc_params, pot, ensemble, n_steps::Int, results::Output, restart, stats)
+
 While initialisation sets `mc_states`, `params` etc. we require something to thermalise our simulation and set the histograms. This function is mostly a wrapper for the [`equilibration_cycle!`](@ref) function that optionally removes the thermalisation from restart.
 
 N.B. Restart is currently non-functional, do not try use it
@@ -326,7 +332,7 @@ function equilibration(
     end
 end
 """
-    (ptmc_run!(mc_params::MCParams, temp::TempGrid, start_config::Config, potential, ensemble; rdfsave = false, restart = false, save = false, saveconfigs = false, configsname = "configuration", workingdirectory = pwd()))
+    ptmc_run!(mc_params::MCParams, temp::TempGrid, start_config::Config, potential, ensemble; rdfsave = false, restart = false, save = false, saveconfigs = false, configsname = "configuration", workingdirectory = pwd())
     ptmc_run!(restart::Bool; rdfsave = false, save = 1000, eq_cycles = 0.2, saveconfigs = false, configsname = "configuration")
 
 Main call for the ptmc program. Given `mc_params` dictating the number of cycles etc. the `temps` containing the temperature and beta values we aim to simulate, an initial `start_config` and the `potential` and `ensemble` we run a complete simulation, explicitly outputting the `mc_states` and `results` structs.

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -36,7 +36,7 @@ Currently implemented for:
         - NNVT ensemble for multiple-species atoms
 """
 function get_energy!(
-    mc_state::MCState{<:Any,<:Any,<:Any,E}, pot::AbstractPotential, movetype::String
+    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,E}, pot::AbstractPotential, movetype::String
 ) where {E<:NVTVariables}
     if movetype == "atommove"
         mc_state.potential_variables, mc_state.new_en = energy_update!(
@@ -52,7 +52,7 @@ function get_energy!(
     return mc_state
 end
 function get_energy!(
-    mc_state::MCState{<:Any,<:Any,<:Any,E}, pot::AbstractDimerPotential, movetype::String
+    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,E}, pot::AbstractDimerPotential, movetype::String
 ) where {E<:NPTVariables}
     if movetype == "atommove"
         mc_state.potential_variables, mc_state.new_en = energy_update!(
@@ -76,7 +76,7 @@ function get_energy!(
     return mc_state
 end
 function get_energy!(
-    mc_state::MCState{<:Any,<:Any,<:Any,E}, pot::AbstractPotential, movetype::String
+    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,E}, pot::AbstractPotential, movetype::String
 ) where {E<:NNVTVariables}
     if movetype == "atommove"
         mc_state.potential_variables, mc_state.new_en = energy_update!(
@@ -112,6 +112,9 @@ and the internal `potential_variables` within the mc_states dictate how [`swap_c
 function acc_test!(mc_state::MCState, ensemble, movetype::String)
     if metropolis_condition(movetype, mc_state, ensemble) >= rand()
         swap_config!(mc_state, movetype)
+        return true
+    else
+        return false
     end
 end
 """
@@ -136,41 +139,43 @@ function mc_move!(
         mc_state, pot, move_strat.movestrat[mc_state.ensemble_variables.index]
     )
 
-    acc_test!(
+    return acc_test!(
         mc_state,
         move_strat.ensemble,
         move_strat.movestrat[mc_state.ensemble_variables.index],
     )
-
-    return mc_state
 end
 
 """
-    mc_step!(mc_states::MCStateVector, move_strat::MoveStrategy{N, E}, pot, ensemble, n_steps::Int) where {N, E}
+    mc_step!(mc_states, move_strat::MoveStrategy{N, E}, pot, ensemble, n_steps::Int) where {N, E}
 
 Distributes each state in `mc_state` to the [`mc_move!`](@ref) function in accordance with a `move_strat`, `ensemble` and `pot`.
 """
 function mc_step!(
-    mc_states::MCStateVector, move_strat::MoveStrategy{N,E}, pot, ensemble, n_steps::Int
+    mc_states, move_strat::MoveStrategy{N,E}, pot, ensemble, n_steps::Int
 ) where {N,E}
     Threads.@threads for state in mc_states
+        n_accepted = 0
+
         for i_step in 1:n_steps
-            state = mc_move!(state, move_strat, pot, ensemble)
+            n_accepted += mc_move!(state, move_strat, pot, ensemble)
         end
+
+        state.acceptance = n_accepted / n_steps
     end
     return mc_states
 end
 
 """
-    mc_cycle!(mc_states::MCStateVector, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, index::Int) where {N, E}
-    mc_cycle!(mc_states::MCStateVector, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, results::Output, idx::Int, rdfsave::Bool) where {N, E}
+    mc_cycle!(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, index::Int) where {N, E}
+    mc_cycle!(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, results::Output, idx::Int, rdfsave::Bool) where {N, E}
 
 Basic function utilised by the simulation. For each of the `n_steps` run a single [`mc_step!`](@ref) on the `mc_states` according to `pot`, `move_strat` and `ensemble`, then complete the [`parallel_tempering_exchange!`](@ref) and `update_step_size!`.
 
 Second method includes the [`sampling_step!`](@ref) which updates the `results` struct. The first method is used by the [`equilibration_cycle!`](@ref) and therefore does __not__ update the results struct.
 """
 function mc_cycle!(
-    mc_states::MCStateVector,
+    mc_states,
     move_strat::MoveStrategy{N,E},
     mc_params::MCParams,
     pot,
@@ -193,7 +198,7 @@ function mc_cycle!(
     return mc_states
 end
 function mc_cycle!(
-    mc_states::MCStateVector,
+    mc_states,
     move_strat::MoveStrategy{N,E},
     mc_params::MCParams,
     pot,
@@ -211,9 +216,34 @@ function mc_cycle!(
     if rem(idx, mc_params.mc_sample) == 0
         sampling_step!(mc_params, mc_states, ensemble, idx, results, rdfsave, idx)
     end
+    for state in mc_states
+        push!(state.stats,
+              (;
+               T=state.temp,
+               hamiltonian=hamiltonian_value(state, ensemble),
+               E_tot=state.en_tot,
+               acceptance=state.acceptance,
+               volume=volume(state.config.boundary_condition),
+               LH_ratio=state.lh_ratio,
+               count_atom=state.count_atom[1],
+               count_vol=state.count_vol[1],
+               count_vol_xy=state.count_vol_xy[1],
+               count_vol_z=state.count_vol_z[1],
+               count_exc=state.count_exc[1],
+               )
+              )
+    end
 
     return mc_states
 end
+
+function hamiltonian_value(state::MCState, ::AbstractEnsemble)
+    return state.en_tot
+end
+function hamiltonian_value(state::MCState, ensemble::NPT)
+    return state.en_tot + ensemble.pressure * volume(state.config.boundary_condition)
+end
+
 """
     check_e_bounds(energy::Number, ebounds::VorS)
 Function to determine if an energy value is greater than or less than the min/max, used in equilibration cycle.
@@ -239,11 +269,11 @@ function reset_counters(state::MCState)
 end
 
 """
-    equilibration_cycle!(mc_states::MCStateVector, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, results::Output) where {N, E}
+    equilibration_cycle!(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, results::Output) where {N, E}
 Function to thermalise a set of `mc_states` ensuring that the number of equilibration cycles defined in `mc_params` are completed without updating the results before initialising the `results` struct according to the maximum and minimum energy determined throughout the equilibration cycle.
 """
 function equilibration_cycle!(
-    mc_states::MCStateVector,
+    mc_states,
     move_strat::MoveStrategy{N,E},
     mc_params::MCParams,
     pot,
@@ -277,13 +307,13 @@ end
 
 #TODO: why is restart not functional?
 """
-    equilibration(mc_states::MCStateVector, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, results::Output, restart::Bool) where {N, E}
+    equilibration(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, results::Output, restart::Bool) where {N, E}
 While initialisation sets `mc_states`, `params` etc. we require something to thermalise our simulation and set the histograms. This function is mostly a wrapper for the [`equilibration_cycle!`](@ref) function that optionally removes the thermalisation from restart.
 
 N.B. Restart is currently non-functional, do not try use it
 """
 function equilibration(
-    mc_states::MCStateVector,
+    mc_states,
     move_strat::MoveStrategy{N,E},
     mc_params::MCParams,
     pot,
@@ -370,7 +400,6 @@ function ptmc_run!(
             rdfsave,
             potential,
         )
-
         if save ≢ false && rem(i, save) == 0
             checkpoint(i, mc_states, results, ensemble, rdfsave)
         end

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -128,17 +128,14 @@ function mc_move!(mc_state::MCState, move_strat::MoveStrategy{N,E}) where {N,E}
     mc_state.ensemble_variables.index = rand(1:N)
 
     mc_state = generate_move!(
-        mc_state, move_strat.movestrat[mc_state.ensemble_variables.index],
+        mc_state, move_strat.movestrat[mc_state.ensemble_variables.index]
     )
 
     mc_state = get_energy!(
         mc_state, move_strat.movestrat[mc_state.ensemble_variables.index]
     )
 
-    return acc_test!(
-        mc_state,
-        move_strat.movestrat[mc_state.ensemble_variables.index],
-    )
+    return acc_test!(mc_state, move_strat.movestrat[mc_state.ensemble_variables.index])
 end
 
 """
@@ -146,9 +143,7 @@ end
 
 Distributes each state in `mc_state` to the [`mc_move!`](@ref) function in accordance with a `move_strat`, `ensemble` and `pot`.
 """
-function mc_step!(
-    mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int, stats
-) where {N,E}
+function mc_step!(mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int, stats) where {N,E}
     Threads.@threads for state in mc_states
         n_accepted = 0
 
@@ -158,8 +153,7 @@ function mc_step!(
 
         state.step += 1
         state.acceptance = n_accepted / n_steps
-        state.last_stats = (
-            ;
+        state.last_stats = (;
             step=state.step,
             T=state.temp,
             hamiltonian=hamiltonian_value(state, state.ensemble),
@@ -172,7 +166,6 @@ function mc_step!(
             count_vol_z=state.count_vol_z[1],
             count_exc=state.count_exc[1],
         )
-
     end
     for state in mc_states
         push!(stats, state.last_stats)
@@ -277,7 +270,6 @@ function equilibration_cycle!(
     results::Output,
     stats,
 ) where {N,E}
-
     ebounds = [100.0, -100.0]
     # Don't touch ebound for the first half of the run in case energies
     # are very high at the beginning.
@@ -440,16 +432,7 @@ function ptmc_run!(
     end
 
     for i in start_counter:(mc_params.mc_cycles)
-        mc_cycle!(
-            mc_states,
-            move_strategy,
-            mc_params,
-            n_steps,
-            results,
-            i,
-            rdfsave,
-            stats,
-        )
+        mc_cycle!(mc_states, move_strategy, mc_params, n_steps, results, i, rdfsave, stats)
         if save ≢ false && rem(i, save) == 0
             checkpoint(i, mc_states, results, ensemble, rdfsave)
         end

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -25,18 +25,16 @@ include("swap_config.jl")
 
 #TODO update energy documentation
 """
-    get_energy!(mc_state::MCState, pot, movetype::String)
-    get_energy!(mc_state::MCState, pot, movetype::String)
-    get_energy!(mc_state::MCState, pot, movetype::String)
+    get_energy!(mc_state::MCState, movetype::String)
 
 Calculates energy for different ensembles and move types.
 Currently implemented for:
-        - NVT ensemble without r_cut
-        - NPT ensemble with r_cut
-        - NNVT ensemble for multiple-species atoms
+- [`NVT`](@ref) ensemble without `r_cut`
+- [`NPT`](@ref) ensemble with `r_cut`
+- [`NNVT`](@ref) ensemble for multiple-species atoms
 """
 function get_energy!(
-    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,E}, pot::AbstractPotential, movetype::String
+    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,E}, movetype::String
 ) where {E<:NVTVariables}
     if movetype == "atommove"
         mc_state.potential_variables, mc_state.new_en = energy_update!(
@@ -46,13 +44,13 @@ function get_energy!(
             mc_state.dist2_mat,
             mc_state.new_dist2_vec,
             mc_state.en_tot,
-            pot,
+            mc_state.potential,
         )
     end
     return mc_state
 end
 function get_energy!(
-    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,E}, pot::AbstractDimerPotential, movetype::String
+    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,E}, movetype::String
 ) where {E<:NPTVariables}
     if movetype == "atommove"
         mc_state.potential_variables, mc_state.new_en = energy_update!(
@@ -62,21 +60,21 @@ function get_energy!(
             mc_state.dist2_mat,
             mc_state.new_dist2_vec,
             mc_state.en_tot,
-            pot,
+            mc_state.potential,
         )
     else
         mc_state.new_en = dimer_energy_config(
             mc_state.ensemble_variables.trial_config,
             mc_state.ensemble_variables.new_dist2_mat,
             mc_state.potential_variables,
-            pot;
+            mc_state.potential;
             new=true,
         )
     end
     return mc_state
 end
 function get_energy!(
-    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,E}, pot::AbstractPotential, movetype::String
+    mc_state::MCState{<:Any,<:Any,<:Any,<:Any,E}, movetype::String
 ) where {E<:NNVTVariables}
     if movetype == "atommove"
         mc_state.potential_variables, mc_state.new_en = energy_update!(
@@ -86,7 +84,7 @@ function get_energy!(
             mc_state.dist2_mat,
             mc_state.new_dist2_vec,
             mc_state.en_tot,
-            pot,
+            mc_state.potential,
         )
     else
         mc_state.potential_variables, mc_state.new_en = swap_energy_update(
@@ -95,22 +93,22 @@ function get_energy!(
             mc_state.potential_variables,
             mc_state.dist2_mat,
             mc_state.en_tot,
-            pot,
+            mc_state.potential,
         )
     end
     return mc_state
 end
 
 """
-    acc_test!(mc_state::MCState,ensemble,movetype::String)
+    acc_test!(mc_state::MCState, movetype::String)
 
 Checks if metropolis condition is fulfilled, comparing it to a random variable in [0,1].
 If the condition is met, the new variables become the current `mc_state` using [`swap_config!`](@ref).
 `ensemble` and `movetype` dictate the exact calculation of the metropolis condition,
 and the internal `potential_variables` within the mc_states dictate how [`swap_config!`](@ref) operates.
 """
-function acc_test!(mc_state::MCState, ensemble, movetype::String)
-    if metropolis_condition(movetype, mc_state, ensemble) >= rand()
+function acc_test!(mc_state::MCState, movetype::String)
+    if metropolis_condition(movetype, mc_state, mc_state.ensemble) >= rand()
         swap_config!(mc_state, movetype)
         return true
     else
@@ -118,7 +116,7 @@ function acc_test!(mc_state::MCState, ensemble, movetype::String)
     end
 end
 """
-    mc_move!(mc_state::MCState,move_strat::MoveStrategy, potential, ensemble)
+    mc_move!(mc_state::MCState,move_strat::MoveStrategy)
 
 Basic move for one `mc_state` according to a `move_strat` dictating the types of moves allowed within the `ensemble` when moving across a `potential` defining the PES.
 -   Calculates an index for the move
@@ -126,22 +124,19 @@ Basic move for one `mc_state` according to a `move_strat` dictating the types of
 -   Calculates energy based on the pot and new move
 -   Tests acc and swaps if relevant
 """
-function mc_move!(
-    mc_state::MCState, move_strat::MoveStrategy{N,E}, pot, ensemble
-) where {N,E}
+function mc_move!(mc_state::MCState, move_strat::MoveStrategy{N,E}) where {N,E}
     mc_state.ensemble_variables.index = rand(1:N)
 
     mc_state = generate_move!(
-        mc_state, move_strat.movestrat[mc_state.ensemble_variables.index], ensemble
+        mc_state, move_strat.movestrat[mc_state.ensemble_variables.index],
     )
 
     mc_state = get_energy!(
-        mc_state, pot, move_strat.movestrat[mc_state.ensemble_variables.index]
+        mc_state, move_strat.movestrat[mc_state.ensemble_variables.index]
     )
 
     return acc_test!(
         mc_state,
-        move_strat.ensemble,
         move_strat.movestrat[mc_state.ensemble_variables.index],
     )
 end
@@ -152,13 +147,13 @@ end
 Distributes each state in `mc_state` to the [`mc_move!`](@ref) function in accordance with a `move_strat`, `ensemble` and `pot`.
 """
 function mc_step!(
-    mc_states, move_strat::MoveStrategy{N,E}, pot, ensemble, n_steps::Int
+    mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int
 ) where {N,E}
     Threads.@threads for state in mc_states
         n_accepted = 0
 
         for i_step in 1:n_steps
-            n_accepted += mc_move!(state, move_strat, pot, ensemble)
+            n_accepted += mc_move!(state, move_strat)
         end
 
         state.acceptance = n_accepted / n_steps
@@ -178,12 +173,11 @@ function mc_cycle!(
     mc_states,
     move_strat::MoveStrategy{N,E},
     mc_params::MCParams,
-    pot,
-    ensemble,
     n_steps::Int,
     index::Int,
 ) where {N,E}
-    mc_states = mc_step!(mc_states, move_strat, pot, ensemble, n_steps)
+    mc_step!(mc_states, move_strat, n_steps)
+    ensemble = mc_states[1].ensemble
 
     if rand() < 0.1
         parallel_tempering_exchange!(mc_states, mc_params, ensemble)
@@ -201,8 +195,6 @@ function mc_cycle!(
     mc_states,
     move_strat::MoveStrategy{N,E},
     mc_params::MCParams,
-    pot,
-    ensemble,
     n_steps::Int,
     results::Output,
     idx::Int,
@@ -211,7 +203,8 @@ function mc_cycle!(
 ) where {N,E}
     #TODO: Implement saving configurations after n steps
 
-    mc_states = mc_cycle!(mc_states, move_strat, mc_params, pot, ensemble, n_steps, idx)
+    mc_cycle!(mc_states, move_strat, mc_params, n_steps, idx)
+    ensemble = mc_states[1].ensemble
 
     if rem(idx, mc_params.mc_sample) == 0
         sampling_step!(mc_params, mc_states, ensemble, idx, results, rdfsave, idx)
@@ -269,15 +262,13 @@ function reset_counters(state::MCState)
 end
 
 """
-    equilibration_cycle!(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, pot, ensemble, n_steps::Int, results::Output) where {N, E}
+    equilibration_cycle!(mc_states, move_strat::MoveStrategy{N, E}, mc_params::MCParams, n_steps::Int, results::Output) where {N, E}
 Function to thermalise a set of `mc_states` ensuring that the number of equilibration cycles defined in `mc_params` are completed without updating the results before initialising the `results` struct according to the maximum and minimum energy determined throughout the equilibration cycle.
 """
 function equilibration_cycle!(
     mc_states,
     move_strat::MoveStrategy{N,E},
     mc_params::MCParams,
-    pot,
-    ensemble,
     n_steps::Int,
     results::Output,
 ) where {N,E}
@@ -287,7 +278,7 @@ function equilibration_cycle!(
     # Don't touch ebound for the first half of the run in case energies
     # are very high at the beginning.
     for i in 1:(mc_params.eq_cycles ÷ 2)
-        mc_states = mc_cycle!(mc_states, move_strat, mc_params, pot, ensemble, n_steps, i)
+        mc_states = mc_cycle!(mc_states, move_strat, mc_params, n_steps, i)
     end
     for i in (mc_params.eq_cycles ÷ 2 + 1):(mc_params.eq_cycles)
         for state in mc_states
@@ -316,8 +307,6 @@ function equilibration(
     mc_states,
     move_strat::MoveStrategy{N,E},
     mc_params::MCParams,
-    pot,
-    ensemble,
     n_steps::Int,
     results::Output,
     restart::Bool,
@@ -331,7 +320,7 @@ function equilibration(
         return mc_states, results
     else
         return equilibration_cycle!(
-            mc_states, move_strat, mc_params, pot, ensemble, n_steps, results
+            mc_states, move_strat, mc_params, n_steps, results
         )
     end
 end
@@ -378,7 +367,7 @@ function ptmc_run!(
 
     # Equilibration
     mc_states, results = equilibration(
-        mc_states, move_strategy, mc_params, potential, ensemble, n_steps, results, restart
+        mc_states, move_strategy, mc_params, n_steps, results, restart
     )
     if save ≢ false
         save_histparams(results)
@@ -392,8 +381,6 @@ function ptmc_run!(
             mc_states,
             move_strategy,
             mc_params,
-            potential,
-            ensemble,
             n_steps,
             results,
             i,
@@ -438,7 +425,7 @@ function ptmc_run!(
     )
 
     mc_states, results = equilibration(
-        mc_states, move_strategy, mc_params, potential, ensemble, n_steps, results, restart
+        mc_states, move_strategy, mc_params, n_steps, results, restart
     )
     @info "equilibration complete"
 
@@ -451,8 +438,6 @@ function ptmc_run!(
             mc_states,
             move_strategy,
             mc_params,
-            potential,
-            ensemble,
             n_steps,
             results,
             i,

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -156,9 +156,9 @@ function mc_step!(mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int, stats)
         state.acceptance = n_accepted / n_steps
         state.last_stats = (;
             step=state.step,
-            T=state.temp,
+            temperature=state.temp,
             hamiltonian=hamiltonian_value(state, state.ensemble),
-            E_tot=state.en_tot,
+            total_energy=state.en_tot,
             acceptance=state.acceptance,
             report_stats(state, state.ensemble)...,
             count_atom=state.count_atom[1],
@@ -167,9 +167,6 @@ function mc_step!(mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int, stats)
             count_vol_z=state.count_vol_z[1],
             count_exc=state.count_exc[1],
         )
-    end
-    for state in mc_states
-        push!(stats, state.last_stats)
     end
     return mc_states
 end
@@ -194,7 +191,9 @@ function mc_cycle!(
     ensemble = mc_states[1].ensemble
 
     if rand() < 0.1
-        parallel_tempering_exchange!(mc_states, mc_params, ensemble)
+        exchange_index = parallel_tempering_exchange!(mc_states, mc_params, ensemble)
+    else
+        exchange_index = 0
     end
     if rem(index, mc_params.n_adjust) == 0
         for state in mc_states
@@ -202,6 +201,10 @@ function mc_cycle!(
                 state, mc_params.n_adjust, ensemble, mc_params.min_acc, mc_params.max_acc
             )
         end
+    end
+    for (i, state) in enumerate(mc_states)
+        exchanged = i ∈ (exchange_index, exchange_index + 1)
+        push!(stats, (; state.last_stats..., exchanged))
     end
     return mc_states
 end

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -433,7 +433,7 @@ function ptmc_run!(
         # write as regular file
         Arrow.write(stats_filename, stats)
         stats = DataFrame(Arrow.Table(stats_filename))
-    else
+    elseif !isnothing(stats_filename)
         # append remaining rows
         Arrow.append(stats_filename, stats)
         stats = DataFrame(Arrow.Table(stats_filename))

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -112,6 +112,9 @@ and the internal `potential_variables` within the mc_states dictate how [`swap_c
 function acc_test!(mc_state::MCState, ensemble, movetype::String)
     if metropolis_condition(movetype, mc_state, ensemble) >= rand()
         swap_config!(mc_state, movetype)
+        return true
+    else
+        return false
     end
 end
 """
@@ -136,13 +139,11 @@ function mc_move!(
         mc_state, pot, move_strat.movestrat[mc_state.ensemble_variables.index]
     )
 
-    acc_test!(
+    return acc_test!(
         mc_state,
         move_strat.ensemble,
         move_strat.movestrat[mc_state.ensemble_variables.index],
     )
-
-    return mc_state
 end
 
 """
@@ -154,9 +155,35 @@ function mc_step!(
     mc_states::MCStateVector, move_strat::MoveStrategy{N,E}, pot, ensemble, n_steps::Int
 ) where {N,E}
     Threads.@threads for state in mc_states
+        n_accepted = 0
+
         for i_step in 1:n_steps
-            state = mc_move!(state, move_strat, pot, ensemble)
+            n_accepted += mc_move!(state, move_strat, pot, ensemble)
         end
+
+        state.acceptance = n_accepted / n_steps
+        if isempty(state.stats)
+            cycle = 1
+        else
+            cycle = state.stats[end].cycle + 1
+        end
+
+        push!(state.stats,
+              (;
+               cycle,
+               T=state.temp,
+               hamiltonian=hamiltonian(state, ensemble),
+               E_tot=state.en_tot,
+               acceptance=state.acceptance,
+               volume=volume(state.config.boundary_condition),
+               LH_ratio=state.lh_ratio,
+               count_atom=state.count_atom[1],
+               count_vol=state.count_vol[1],
+               count_vol_xy=state.count_vol_xy[1],
+               count_vol_z=state.count_vol_z[1],
+               count_exc=state.count_exc[1],
+               )
+              )
     end
     return mc_states
 end
@@ -214,6 +241,7 @@ function mc_cycle!(
 
     return mc_states
 end
+
 """
     check_e_bounds(energy::Number, ebounds::VorS)
 Function to determine if an energy value is greater than or less than the min/max, used in equilibration cycle.
@@ -370,7 +398,6 @@ function ptmc_run!(
             rdfsave,
             potential,
         )
-
         if save ≢ false && rem(i, save) == 0
             checkpoint(i, mc_states, results, ensemble, rdfsave)
         end

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -168,22 +168,23 @@ function mc_step!(
             cycle = state.stats[end].cycle + 1
         end
 
-        push!(state.stats,
-              (;
-               cycle,
-               T=state.temp,
-               hamiltonian=hamiltonian(state, ensemble),
-               E_tot=state.en_tot,
-               acceptance=state.acceptance,
-               volume=volume(state.config.boundary_condition),
-               LH_ratio=state.lh_ratio,
-               count_atom=state.count_atom[1],
-               count_vol=state.count_vol[1],
-               count_vol_xy=state.count_vol_xy[1],
-               count_vol_z=state.count_vol_z[1],
-               count_exc=state.count_exc[1],
-               )
-              )
+        push!(
+            state.stats,
+            (;
+                cycle,
+                T=state.temp,
+                hamiltonian=hamiltonian(state, ensemble),
+                E_tot=state.en_tot,
+                acceptance=state.acceptance,
+                volume=volume(state.config.boundary_condition),
+                LH_ratio=state.lh_ratio,
+                count_atom=state.count_atom[1],
+                count_vol=state.count_vol[1],
+                count_vol_xy=state.count_vol_xy[1],
+                count_vol_z=state.count_vol_z[1],
+                count_exc=state.count_exc[1],
+            ),
+        )
     end
     return mc_states
 end

--- a/src/MCRun.jl
+++ b/src/MCRun.jl
@@ -5,7 +5,7 @@ export exc_acceptance, exc_trajectories!
 export acc_test!, check_e_bounds, reset_counters, equilibration_cycle!, equilibration
 export mc_move!
 
-using StaticArrays, DelimitedFiles, ProgressMeter, DataFrames
+using StaticArrays, DelimitedFiles, ProgressMeter, DataFrames, Arrow
 using ..MCStates
 using ..BoundaryConditions
 using ..Configurations
@@ -155,7 +155,7 @@ function mc_step!(mc_states, move_strat::MoveStrategy{N,E}, n_steps::Int, stats)
         state.step += 1
         state.acceptance = n_accepted / n_steps
         state.last_stats = (;
-            step=state.step,
+            cycle=state.step,
             temperature=state.temp,
             hamiltonian=hamiltonian_value(state, state.ensemble),
             total_energy=state.en_tot,
@@ -364,6 +364,8 @@ function ptmc_run!(
     saveconfigs=false,
     configsname="configuration",
     workingdirectory=pwd(),
+    flush_interval=1_000_000,
+    stats_filename=nothing,
 )
     # Initialisation
     cd(workingdirectory)
@@ -371,6 +373,17 @@ function ptmc_run!(
         save_init(potential, ensemble, mc_params, temp)
     end
     stats = DataFrame()
+
+    if !isnothing(stats_filename)
+        counter = 0
+        base, ext = splitext(stats_filename)
+        while isfile(stats_filename)
+            counter += 1
+            new_filename = string("$base-$counter", ext)
+            @warn "File $stats_filename exists. Using $new_filename"
+            stats_filename = new_filename
+        end
+    end
 
     mc_states, move_strategy, results, n_steps, start_counter = initialisation(
         mc_params, temp, start_config, potential, ensemble
@@ -383,6 +396,7 @@ function ptmc_run!(
     if save ≢ false
         save_histparams(results)
     end
+
 
     # Main loop
     progress = Progress(length(start_counter:(mc_params.mc_cycles)); desc="Main loop")
@@ -404,12 +418,26 @@ function ptmc_run!(
         if saveconfigs ≢ false && rem(i, saveconfigs) == 0
             save_configs(mc_states, string(configsname, i))
         end
+        if !isnothing(stats_filename) && i % flush_interval == 0
+            @info "Flushing data to disk"
+            Arrow.append(stats_filename, stats)
+            empty!(stats)
+        end
         next!(progress)
     end
 
     if save ≢ false && rem(mc_params.mc_cycles, save) ≠ 0
         # Save at the end if we didn't save in the last step.
         checkpoint(mc_params.mc_cycles, mc_states, results, ensemble, rdfsave)
+    end
+    if !isnothing(stats_filename) && flush_interval < mc_params.mc_cycles
+        # write as regular file
+        Arrow.write(stats_filename, stats)
+        stats = DataFrame(Arrow.Table(stats_filename))
+    else
+        # append remaining rows
+        Arrow.append(stats_filename, stats)
+        stats = DataFrame(Arrow.Table(stats_filename))
     end
 
     #Finalisation of results

--- a/src/MCStates.jl
+++ b/src/MCStates.jl
@@ -11,18 +11,37 @@ using ..CustomTypes
 export MCState, max_length#, NNPState
 
 """
-    MCState(temp::Number, beta::Number, config::Config, dist2_mat::Matrix{Number}, new_dist2_vec::VorS, new_en::Number, en_tot::Number, potentialvariables::AbstractPotentialVariables, ensemble_variables::AbstractEnsembleVariables; max_displ = [0.1, 0.1, 1.0], max_boxlength = max_length(config.boundary_condition), count_atom = [0, 0], count_vol = [0, 0], count_exc = [0, 0]) where {T, N, BC}
-    MCState(temp::Number, beta::Number, config::Config, ensemble, pot; kwargs...)
-Creates an MC state vector at a given temperature `temp` containing temperature-dependent information
+    MCState(
+        temp,
+        beta,
+        config,
+        dist2_mat,
+        new_dist2_vec,
+        new_en,
+        en_tot,
+        potential,
+        potential_variables,
+        ensemble,
+        ensemble_variables;
+        max_displ = [0.1, 0.1, 1.0],
+        max_boxlength = max_length(config.boundary_condition),
+        count_atom = [0, 0],
+        count_vol = [0, 0],
+        count_exc = [0, 0]
+    )
+    MCState(temp, config, ensemble, potential; kwargs...)
 
--   Fieldnames:
+Monte Carlo state for a given temperature `temp` containing all information required to
+perform a Monte Carlo step.
+
+## Fields
     -   `temp`: temperature
     -   `beta`: inverse temperature
     -   `config`: actual configuration in Markov chain [`Config`](@ref)
-    -   `dist_2mat`: matrix of squared distances d_ij between atoms i and j; generated automatically when potential `pot` given
+    -   `dist_2mat`: matrix of squared distances d_ij between atoms i and j; generated automatically when potential `potential` given
     -   `new_dist2_vec`: calculates the new r2 between atoms based on a trial move
     -   `new_en` : new energy value for trial configuraiton
-    -   `en_tot`: total energy of `config`; generated automatically when `pot` given
+    -   `en_tot`: total energy of `config`; generated automatically when `potential` given
     -   `potential_variables` : mutable struct containing energy-related variables for the current configuration
     -   `ensemble_variables` : mutable struct containing ensemble-related variables for the current configuraiton
     -   `ham`: vector containing sampled energies - generated in MC run
@@ -30,30 +49,32 @@ Creates an MC state vector at a given temperature `temp` containing temperature-
     -   `count_vol`: number of accepted volume moves - total and between adjustment of step sizes; key-word argument
     -   `count_exc`: number of attempted (10%) and accepted exchanges with neighbouring trajectories; key-word argument
 """
-mutable struct MCState{T,BC,PVType,EVType}
-    temp::T
-    beta::T
-    config::Config{T,BC}
-    dist2_mat::Matrix{T}
-    new_dist2_vec::Vector{T}
-    new_en::T
-    en_tot::T
-    potential_variables::PVType
-    ensemble_variables::EVType
-    ham::Vector{T}
-    max_displ::Vector{T}
-    max_boxlength::T
-    max_boxheight::T
-    lh_ratio::T
+mutable struct MCState{BC,P,PV,E,EV}
+    temp::Float64
+    beta::Float64
+    config::Config{Float64,BC}
+    dist2_mat::Matrix{Float64}
+    new_dist2_vec::Vector{Float64}
+    new_en::Float64
+    en_tot::Float64
+    potential::P
+    potential_variables::PV
+    ensemble::E
+    ensemble_variables::EV
+    ham::Vector{Float64}
+    max_displ::Vector{Float64}
+    max_boxlength::Float64
+    max_boxheight::Float64
+    lh_ratio::Float64
     count_atom::Vector{Int}
     count_vol::Vector{Int}
     count_vol_xy::Vector{Int}
     count_vol_z::Vector{Int}
     count_exc::Vector{Int}
+    acceptance::Float64
+    stats::Vector
 end
 
-const MCStateVector = Vector{T} where {T<:MCState}
-export MCStateVector
 """
     max_length(bc::SphericalBC)
     max_length(bc::CubicBC)
@@ -86,21 +107,18 @@ function max_height(bc::RectangularBC)
     return bc.box_height * 1.8
 end
 
-"""
-    (MCState(temp::Number, beta::Number, config::Config, dist2_mat::Matrix{Z}, new_dist2_vec::VorS, new_en::Number, en_tot::Number, potentialvariables::AbstractPotentialVariables, ensemble_variables::AbstractEnsembleVariables; max_displ = [0.1, 0.1, 1.0], max_boxlength = max_length(config.boundary_condition), count_atom = [0, 0], count_vol = [0, 0], count_exc = [0, 0]) where {T, N, BC}) where Z <: Number
-    MCState(temp::Number, beta::Number, config::Config, ensemble, pot; kwargs...)
-Constructor for the [`MCState`](@ref) struct.
-"""
 function MCState(
-    temp::Number,
-    beta::Number,
-    config::Config{T,BC},
-    dist2_mat::Matrix{Z},
-    new_dist2_vec::VorS,
-    new_en::Number,
-    en_tot::Number,
-    potentialvariables::AbstractPotentialVariables,
-    ensemble_variables::AbstractEnsembleVariables;
+    temp::Float64,
+    beta::Float64,
+    config::Config{Float64,BC},
+    dist2_mat,
+    new_dist2_vec,
+    new_en,
+    en_tot,
+    potential::P,
+    potential_variables::PV,
+    ensemble::E,
+    ensemble_variables::EV;
     max_displ=[0.1, 0.1, 0.1, 0.1],
     max_boxlength=max_length(config.boundary_condition),
     max_boxheight=max_height(config.boundary_condition),
@@ -110,9 +128,8 @@ function MCState(
     count_vol_xy=[0, 0],
     count_vol_z=[0, 0],
     count_exc=[0, 0],
-) where {T,BC} where {Z<:Number}
-    ham = T[]
-    return MCState{T,BC,typeof(potentialvariables),typeof(ensemble_variables)}(
+) where {BC,P,PV,E,EV}
+    return MCState{BC,P,PV,E,EV}(
         temp,
         beta,
         deepcopy(config),
@@ -120,9 +137,11 @@ function MCState(
         copy(new_dist2_vec),
         new_en,
         en_tot,
-        deepcopy(potentialvariables),
+        potential,
+        deepcopy(potential_variables),
+        ensemble,
         deepcopy(ensemble_variables),
-        ham,
+        Float64[],
         copy(max_displ),
         copy(max_boxlength),
         copy(max_boxheight),
@@ -132,17 +151,21 @@ function MCState(
         copy(count_vol_xy),
         copy(count_vol_z),
         copy(count_exc),
+        0.0,
+        [],
     )
 end
-function MCState(temp::Number, beta::Number, config::Config, ensemble, pot; kwargs...)
+function MCState(temp, config, ensemble, potential; kwargs...)
+    beta = inv(temp * 3.16681196E-6)
+
     dist2_mat = get_distance2_mat(config)
     n_atoms = length(config)
 
-    potential_variables = set_variables(config, dist2_mat, pot)
+    potential_variables = set_variables(config, dist2_mat, potential)
     ensemble_variables = set_ensemble_variables(config, ensemble)
 
     en_tot, potential_variables = initialise_energy(
-        config, dist2_mat, potential_variables, ensemble_variables, pot
+        config, dist2_mat, potential_variables, ensemble_variables, potential
     )
 
     return MCState(
@@ -153,7 +176,9 @@ function MCState(temp::Number, beta::Number, config::Config, ensemble, pot; kwar
         zeros(n_atoms),
         0.0,
         en_tot,
+        potential,
         potential_variables,
+        ensemble,
         ensemble_variables;
         kwargs...,
     )

--- a/src/MCStates.jl
+++ b/src/MCStates.jl
@@ -50,6 +50,8 @@ mutable struct MCState{T,BC,PVType,EVType}
     count_vol_xy::Vector{Int}
     count_vol_z::Vector{Int}
     count_exc::Vector{Int}
+    acceptance::Float64
+    stats::Vector{NamedTuple}
 end
 
 const MCStateVector = Vector{T} where {T<:MCState}
@@ -95,7 +97,7 @@ function MCState(
     temp::Number,
     beta::Number,
     config::Config{T,BC},
-    dist2_mat::Matrix{Z},
+    dist2_mat::Matrix{T},
     new_dist2_vec::VorS,
     new_en::Number,
     en_tot::Number,
@@ -110,7 +112,7 @@ function MCState(
     count_vol_xy=[0, 0],
     count_vol_z=[0, 0],
     count_exc=[0, 0],
-) where {T,BC} where {Z<:Number}
+) where {T,BC}
     ham = T[]
     return MCState{T,BC,typeof(potentialvariables),typeof(ensemble_variables)}(
         temp,
@@ -132,6 +134,8 @@ function MCState(
         copy(count_vol_xy),
         copy(count_vol_z),
         copy(count_exc),
+        0.0,
+        NamedTuple[],
     )
 end
 function MCState(temp::Number, beta::Number, config::Config, ensemble, pot; kwargs...)

--- a/src/MCStates.jl
+++ b/src/MCStates.jl
@@ -72,7 +72,8 @@ mutable struct MCState{BC,P,PV,E,EV}
     count_vol_z::Vector{Int}
     count_exc::Vector{Int}
     acceptance::Float64
-    stats::Vector
+    step::Int
+    last_stats::NamedTuple # TODO: check if this need to be type-stable
 end
 
 """
@@ -152,7 +153,8 @@ function MCState(
         copy(count_vol_z),
         copy(count_exc),
         0.0,
-        [],
+        0,
+        NamedTuple(),
     )
 end
 function MCState(temp, config, ensemble, potential; kwargs...)

--- a/src/ReadSave.jl
+++ b/src/ReadSave.jl
@@ -157,27 +157,27 @@ function checkpoint_config(filename, state::MCState)
     end
 end
 """
-    save_configs(mc_states::MCStateVector, filename::AbstractString="config")
+    save_configs(mc_states, filename::AbstractString="config")
 
 Function to save the configuration of each state in a vector of `mc_states`.
 Writes each configuration according to [`checkpoint_config`](@ref) into a file `filename.i`
 where `i` indicates the order of the states.
 Default file name is "config".
 """
-function save_configs(mc_states::MCStateVector, filename::AbstractString="config")
+function save_configs(mc_states, filename::AbstractString="config")
     for saveindex in eachindex(mc_states)
         checkpoint_file = string("./checkpoint/", filename, "T", saveindex, ".xyz")
         checkpoint_config(checkpoint_file, mc_states[saveindex])
     end
 end
 """
-    checkpoint(index::Int, mc_states::MCStateVector, results::Output, ensemble::AbstractEnsemble, rdfsave::Bool)
-    checkpoint(index::Int, mc_states::MCStateVector, results::Output, ensemble::NPT, rdfsave::Bool)
+    checkpoint(index::Int, mc_states, results::Output, ensemble::AbstractEnsemble, rdfsave::Bool)
+    checkpoint(index::Int, mc_states, results::Output, ensemble::NPT, rdfsave::Bool)
 Function to save relevant information about the current state of the system at step `index`. Saves the configurations in each `mc_state` [`save_configs`](@ref) as well as the histograms stored in `results`. Optionally stores the volume histograms if using the NPT ensemble and the radial distribution functions if desired.
 """
 function checkpoint(
     index::Int,
-    mc_states::MCStateVector,
+    mc_states,
     results::Output,
     ensemble::AbstractEnsemble,
     rdfsave::Bool,
@@ -197,7 +197,7 @@ function checkpoint(
     end
 end
 function checkpoint(
-    index::Int, mc_states::MCStateVector, results::Output, ensemble::NPT, rdfsave::Bool
+    index::Int, mc_states, results::Output, ensemble::NPT, rdfsave::Bool
 )
     indexfile = open("./checkpoint/index.txt", "w+")
     writedlm(indexfile, index)
@@ -466,7 +466,6 @@ function rebuild_states(
 
         state = MCState(
             temps.t_grid[index],
-            temps.beta_grid[index],
             conf,
             ensemble,
             potential;
@@ -502,7 +501,7 @@ function build_states(
         end
 
         mc_states = [
-            MCState(temp.t_grid[i], temp.beta_grid[i], confvec[i], ensemble, potential) for
+            MCState(temp.t_grid[i], confvec[i], ensemble, potential) for
             i in 1:(mc_params.n_traj)
         ]
         results = Output{Float64}(mc_params.n_bin; en_min=mc_states[1].en_tot)
@@ -511,7 +510,7 @@ function build_states(
         confinfo = readdlm("./checkpoint/config.data")
         start_config = read_config(confinfo)
         mc_states = [
-            MCState(temp.t_grid[i], temp.beta_grid[i], start_config, ensemble, potential)
+            MCState(temp.t_grid[i], start_config, ensemble, potential)
             for i in 1:(mc_params.n_traj)
         ]
         results = Output{Float64}(mc_params.n_bin; en_min=mc_states[1].en_tot)

--- a/src/ReadSave.jl
+++ b/src/ReadSave.jl
@@ -22,12 +22,12 @@ export read_init, setresults, rebuild_states, read_config, build_states
 Function to write the `mc_params` and `temp` data into a `savefile`. These are static parameters that define how the simulation is to proceed such as the number of cycles, trajectories and the temperatures to be covered.
 """
 function writeparams(savefile::IO, params::MCParams, temp::TempGrid)
-    headersvec =
-        ["cycles:" "sample_rate:" "n_traj:" "n_atoms:" "n_adjust" "n_bins" "min_acc:" "max_acc" "t_i:" "t_f"]
-    paramsvec =
-        [params.mc_cycles params.mc_sample params.n_traj params.n_atoms params.n_adjust params.n_bin params.min_acc params.max_acc first(
-            temp.t_grid
-        ) last(temp.t_grid)]
+    headersvec = [
+        "cycles:" "sample_rate:" "n_traj:" "n_atoms:" "n_adjust" "n_bins" "min_acc:" "max_acc" "t_i:" "t_f"
+    ]
+    paramsvec = [
+        params.mc_cycles params.mc_sample params.n_traj params.n_atoms params.n_adjust params.n_bin params.min_acc params.max_acc first(temp.t_grid) last(temp.t_grid)
+    ]
     return writedlm(savefile, [headersvec, paramsvec], ' ')
 end
 """
@@ -42,16 +42,19 @@ function writeensemble(savefile::IO, ensemble::NVT)
     return writedlm(savefile, [headersvec, valuesvec], ' ')
 end
 function writeensemble(savefile::IO, ensemble::NPT)
-    headersvec =
-        ["ensemble" "n_atom_moves" "n_volume_moves" "n_atom_swaps" "pressure" "separated_volume"]
-    valuesvec =
-        ["NPT" ensemble.n_atoms ensemble.n_atom_moves ensemble.n_volume_moves ensemble.n_atom_swaps ensemble.pressure ensemble.separated_volume]
+    headersvec = [
+        "ensemble" "n_atom_moves" "n_volume_moves" "n_atom_swaps" "pressure" "separated_volume"
+    ]
+    valuesvec = [
+        "NPT" ensemble.n_atoms ensemble.n_atom_moves ensemble.n_volume_moves ensemble.n_atom_swaps ensemble.pressure ensemble.separated_volume
+    ]
     return writedlm(savefile, [headersvec, valuesvec], ' ')
 end
 function writeensemble(savefile::IO, ensemble::NNVT)
     headersvec = ["ensemble" "n_1" "n_2" "n_atom_moves" "n_atom_swaps"]
-    valuesvec =
-        ["NNVT" ensemble.natoms[1] ensemble.natoms[2] ensemble.n_atom_moves ensemble.n_atom_swaps]
+    valuesvec = [
+        "NNVT" ensemble.natoms[1] ensemble.natoms[2] ensemble.n_atom_moves ensemble.n_atom_swaps
+    ]
     return writedlm(savefile, [headersvec, valuesvec], ' ')
 end
 """
@@ -119,8 +122,9 @@ function save_histparams(results::Output)
     # else
     resfile = open("./checkpoint/hist_info.data", "w+")
     headersvec = ["e_min" "e_max" "v_min" "v_max" "Δ_E" "Δ_V" "Δ_r2"]
-    infovec =
-        [results.en_min results.en_max results.v_min results.v_max results.delta_en_hist results.delta_v_hist results.delta_r2]
+    infovec = [
+        results.en_min results.en_max results.v_min results.v_max results.delta_en_hist results.delta_v_hist results.delta_r2
+    ]
     writedlm(resfile, [headersvec, infovec], ' ')
     return close(resfile)
     # end
@@ -176,11 +180,7 @@ end
 Function to save relevant information about the current state of the system at step `index`. Saves the configurations in each `mc_state` [`save_configs`](@ref) as well as the histograms stored in `results`. Optionally stores the volume histograms if using the NPT ensemble and the radial distribution functions if desired.
 """
 function checkpoint(
-    index::Int,
-    mc_states,
-    results::Output,
-    ensemble::AbstractEnsemble,
-    rdfsave::Bool,
+    index::Int, mc_states, results::Output, ensemble::AbstractEnsemble, rdfsave::Bool
 )
     indexfile = open("./checkpoint/index.txt", "w+")
     writedlm(indexfile, index)
@@ -196,9 +196,7 @@ function checkpoint(
     else
     end
 end
-function checkpoint(
-    index::Int, mc_states, results::Output, ensemble::NPT, rdfsave::Bool
-)
+function checkpoint(index::Int, mc_states, results::Output, ensemble::NPT, rdfsave::Bool)
     indexfile = open("./checkpoint/index.txt", "w+")
     writedlm(indexfile, index)
     close(indexfile)
@@ -510,8 +508,8 @@ function build_states(
         confinfo = readdlm("./checkpoint/config.data")
         start_config = read_config(confinfo)
         mc_states = [
-            MCState(temp.t_grid[i], start_config, ensemble, potential)
-            for i in 1:(mc_params.n_traj)
+            MCState(temp.t_grid[i], start_config, ensemble, potential) for
+            i in 1:(mc_params.n_traj)
         ]
         results = Output{Float64}(mc_params.n_bin; en_min=mc_states[1].en_tot)
     end

--- a/src/Sampling.jl
+++ b/src/Sampling.jl
@@ -26,7 +26,7 @@ Function to update the current energy and energy squared values for coarse analy
 """
 function update_energy_tot(mc_states, ensemble::AbstractEnsemble)
     for state in mc_states
-        ham = hamiltonian_value(state, ensemble)
+        ham = hamiltonian(state, ensemble)
         state.ham[1] += ham
         state.ham[2] += ham^2
     end
@@ -242,9 +242,7 @@ end
 Self explanatory name, updates the energy histograms in `results` using the current `mc_states.en_tot`
 
 """
-function update_histograms!(
-    mc_states, results::Output, delta_en_hist::Number
-)
+function update_histograms!(mc_states, results::Output, delta_en_hist::Number)
     for i_traj in eachindex(mc_states)
         histindex = find_hist_index(mc_states[i_traj], results, delta_en_hist)
         results.en_histogram[i_traj][histindex] += 1
@@ -381,10 +379,6 @@ function finalise_results(mc_states, mc_params::MCParams, results::Output)
         mc_states[i_traj].count_exc[2] / mc_states[i_traj].count_exc[1] for
         i_traj in 1:(mc_params.n_traj)
     ]
-    for state in mc_states
-        append!(results.stats, state.stats)
-    end
-
     return results
 end
 

--- a/src/Sampling.jl
+++ b/src/Sampling.jl
@@ -26,17 +26,9 @@ Function to update the current energy and energy squared values for coarse analy
 """
 function update_energy_tot(mc_states::MCStateVector, ensemble::AbstractEnsemble)
     for state in mc_states
-        state.ham[1] += state.en_tot
-        state.ham[2] += (state.en_tot * state.en_tot)
-    end
-end
-function update_energy_tot(mc_states::MCStateVector, ensemble::NPT)
-    for state in mc_states
-        state.ham[1] +=
-            state.en_tot + ensemble.pressure * volume(state.config.boundary_condition)
-        state.ham[2] +=
-            (state.en_tot + ensemble.pressure * volume(state.config.boundary_condition)) *
-            (state.en_tot + ensemble.pressure * volume(state.config.boundary_condition))
+        ham = hamiltonian(state, ensemble)
+        state.ham[1] += ham
+        state.ham[2] += ham^2
     end
 end
 """
@@ -389,6 +381,9 @@ function finalise_results(mc_states::MCStateVector, mc_params::MCParams, results
         mc_states[i_traj].count_exc[2] / mc_states[i_traj].count_exc[1] for
         i_traj in 1:(mc_params.n_traj)
     ]
+    for state in mc_states
+        append!(results.stats, state.stats)
+    end
 
     return results
 end

--- a/src/Sampling.jl
+++ b/src/Sampling.jl
@@ -20,17 +20,17 @@ using ..BoundaryConditions
 using ..EnergyEvaluation
 using ..Ensembles
 """
-    update_energy_tot(mc_states::MCStateVector, ensemble)
+    update_energy_tot(mc_states, ensemble)
 
 Function to update the current energy and energy squared values for coarse analysis of averages at the end. These are weighted according to the ensemble, and as such a method for each ensemble is required.
 """
-function update_energy_tot(mc_states::MCStateVector, ensemble::AbstractEnsemble)
+function update_energy_tot(mc_states, ensemble::AbstractEnsemble)
     for state in mc_states
         state.ham[1] += state.en_tot
         state.ham[2] += (state.en_tot * state.en_tot)
     end
 end
-function update_energy_tot(mc_states::MCStateVector, ensemble::NPT)
+function update_energy_tot(mc_states, ensemble::NPT)
     for state in mc_states
         state.ham[1] +=
             state.en_tot + ensemble.pressure * volume(state.config.boundary_condition)
@@ -245,13 +245,13 @@ function initialise_histograms!(mc_params, results, e_bounds, bc::RectangularBC)
 end
 
 """
-    update_histograms!(mc_states::MCStateVector, results::Output, delta_en_hist::Number)
-    update_histograms!(mc_states::MCStateVector, results::Output, delta_en_hist::Number, delta_v_hist::Number)
+    update_histograms!(mc_states, results::Output, delta_en_hist::Number)
+    update_histograms!(mc_states, results::Output, delta_en_hist::Number, delta_v_hist::Number)
 Self explanatory name, updates the energy histograms in `results` using the current `mc_states.en_tot`
 
 """
 function update_histograms!(
-    mc_states::MCStateVector, results::Output, delta_en_hist::Number
+    mc_states, results::Output, delta_en_hist::Number
 )
     for i_traj in eachindex(mc_states)
         histindex = find_hist_index(mc_states[i_traj], results, delta_en_hist)
@@ -260,7 +260,7 @@ function update_histograms!(
 end
 
 function update_histograms!(
-    mc_states::MCStateVector, results::Output, delta_en_hist::Number, delta_v_hist::Number
+    mc_states, results::Output, delta_en_hist::Number, delta_v_hist::Number
 )
     for i_traj in eachindex(mc_states)
         histindex_e, histindex_v = find_hist_index(
@@ -289,11 +289,11 @@ function update_lh_histograms!(mc_states, results)
 end
 
 """
-    update_rdf!(mc_states::MCStateVector, results::Output, delta_r2::Number)
+    update_rdf!(mc_states, results::Output, delta_r2::Number)
 Self explanatory name, iterates over `mc_states` and adds to the appropriate `results.rdf` histogram. Type stable by the initialise function specifying a vector of integers.
 
 """
-function update_rdf!(mc_states::MCStateVector, results::Output, delta_r2::Number)
+function update_rdf!(mc_states, results::Output, delta_r2::Number)
     for j_traj in eachindex(mc_states)
         #for element in mc_states[j_traj].dist2_mat
         for i in 1:length(mc_states[1].config)
@@ -310,8 +310,8 @@ function update_rdf!(mc_states::MCStateVector, results::Output, delta_r2::Number
     end
 end
 """
-    sampling_step!(mc_params::MCParams, mc_states::MCStateVector, ensemble::AbstractEnsemble, save_index::Int, results::Output, rdfsave::Bool)
-    sampling_step!(mc_params::MCParams, mc_states::MCStateVector, ensemble::NPT, save_index::Int, results::Output, rdfsave::Bool)
+    sampling_step!(mc_params::MCParams, mc_states, ensemble::AbstractEnsemble, save_index::Int, results::Output, rdfsave::Bool)
+    sampling_step!(mc_params::MCParams, mc_states, ensemble::NPT, save_index::Int, results::Output, rdfsave::Bool)
 Function performed at the end of an [`mc_cycle!`](@ref Main.ParallelTemperingMonteCarlo.MCRun.mc_cycle!) after equilibration. Updates the `E,E**2` totals for each `mc_state`, updates the energy and radial histograms and then returns the modified `mc_states` and `results`.
 
 N.B. we have now included the `delta_en`, `delta_v` and `delta_r2` values in the `results` struct to allow for more general methods such as this.
@@ -324,7 +324,7 @@ This function benchmarked at 7.84μs, the update RDF step takes 7.545μs of this
 """
 function sampling_step!(
     mc_params::MCParams,
-    mc_states::MCStateVector,
+    mc_states,
     ensemble::AbstractEnsemble,
     save_index::Int,
     results::Output,
@@ -344,7 +344,7 @@ function sampling_step!(
 end
 function sampling_step!(
     mc_params::MCParams,
-    mc_states::MCStateVector,
+    mc_states,
     ensemble::NPT,
     save_index::Int,
     results::Output,
@@ -366,10 +366,10 @@ function sampling_step!(
 end
 
 """
-    finalise_results(mc_states::MCStateVector, mc_params::MCParams, results::Output)
+    finalise_results(mc_states, mc_params::MCParams, results::Output)
 Function designed to take a complete MC simulation and calculate the averages.
 """
-function finalise_results(mc_states::MCStateVector, mc_params::MCParams, results::Output)
+function finalise_results(mc_states, mc_params::MCParams, results::Output)
 
     #Energy average
     n_sample = mc_params.mc_cycles / mc_params.mc_sample

--- a/src/multihist_NPT.jl
+++ b/src/multihist_NPT.jl
@@ -116,7 +116,7 @@ function multihistogram_NPT(
     results::Output,
     conv_threshold,
     readfile::Bool;
-    show_progress=true,
+    show_progress=isinteractive(),
     maxiter=1000,
 )
     if readfile == false

--- a/src/multihist_NPT.jl
+++ b/src/multihist_NPT.jl
@@ -1,6 +1,7 @@
 module Multihistogram_NPT
 
 using DelimitedFiles, LinearAlgebra, StaticArrays
+using ProgressMeter
 
 using ..InputParams
 using ..Ensembles
@@ -103,10 +104,9 @@ function quasiprob(
 end
 
 """
-    multihistogram_NPT(ensemble::AbstractEnsemble, temp::TempGrid, results::Output, conv_threshold::Number, readfile::Bool; debug = false)
+    multihistogram_NPT(ensemble::AbstractEnsemble, temp::TempGrid, results::Output, conv_threshold::Number, readfile::Bool; show_progress=true)
 Multihistogram analysis for NPT:
 -   `conv_threshold` is the convergence threshold, which user can choose.
--   `debug` kwarg determines whether to print debug information. Defaults to false.
 -   Now "readfile" can only be false.
 -   Example: `multihistogram_NPT(ensemble, temp, results, 10^(-3), false)`
 """
@@ -114,9 +114,10 @@ function multihistogram_NPT(
     ensemble::AbstractEnsemble,
     temp::TempGrid,
     results::Output,
-    conv_threshold::Number,
+    conv_threshold,
     readfile::Bool;
-    debug=false,
+    show_progress=true,
+    maxiter=1000,
 )
     if readfile == false
         tempnumber, tempnumber_result = temp_trajectories(temp)
@@ -132,10 +133,9 @@ function multihistogram_NPT(
         EVhistogram, Ebins, Vbins, tempnumber, tempnumber_result
     )
 
-    for it in 1:1000
-        println("iteration=", it)
+    progress = ProgressThresh(conv_threshold; enabled=show_progress)
+    for it in 1:maxiter
         for i in 1:tempnumber
-            local betat
             betat = beta[i]
             new_free_energy[i] = 0
             for m in 1:Ebins
@@ -158,23 +158,17 @@ function multihistogram_NPT(
                         )
                 end
             end
-
-            #println(new_free_energy[i])
             new_free_energy[i] = log(new_free_energy[i])
-            #println(new_free_energy[i])
         end
 
-        local delta
-        delta = 0
+        delta = 0.0
         for i in 1:tempnumber
             delta = delta + abs(new_free_energy[i] - free_energy[i])^2
             free_energy[i] = new_free_energy[i]
         end
-        println(delta)
-        println()
 
+        update!(progress, delta)
         if delta < conv_threshold
-            println("iteration finished")
             break             #if converged, exit the loop
         end
     end
@@ -239,17 +233,9 @@ function multihistogram_NPT(
                 eenthalpy2 += qp * (energy_t + p * volume)^2
             end
         end
-        #println("temperature: ", temp_result[i])
-        #println("energy: ", eenergy)
-        #println("volume: ", evolume)
-        #println("enthalpy: ", eenthalpy)
-        #println("heat capacity: ", (eenthalpy2 - eenthalpy^2) / (k * temp_result[i]^2))
-        #println()
         cp[i] = (eenthalpy2 - eenthalpy^2) / (k * temp_result[i]^2)
         vol[i] = evolume
     end
-    #println("temperature array: ", temp_result)
-    #println("heat capacity array: ", cp)
 
     return (; T=temp_result, C=cp, V=vol)
 end

--- a/src/multihist_NVT.jl
+++ b/src/multihist_NVT.jl
@@ -1,6 +1,6 @@
 module Multihistogram_NVT
 
-using DelimitedFiles, LinearAlgebra, StaticArrays
+using DelimitedFiles, LinearAlgebra, StaticArrays, ProgressMeter
 
 using ..InputParams
 using ..EnergyEvaluation
@@ -85,10 +85,9 @@ function quasiprob(
 end
 
 """
-    multihistogram_NVT(ensemble::AbstractEnsemble, temp::TempGrid, results::Output, conv_threshold::Number, readfile::Bool; debug = false)
+    multihistogram_NVT(ensemble::AbstractEnsemble, temp::TempGrid, results::Output, conv_threshold::Number, readfile::Bool; show_progress=true)
 Multihistogram analysis for NVT:
 -   `conv_threshold` is the convergence threshold, which user can choose.
--   `debug` kwarg determines whether to print debug information. Defaults to false.
 -   `readfile` can only be false.
 -   Example: `multihistogram_NVT(ensemble, temp, results, 10^(-3), false)`
 """
@@ -98,7 +97,8 @@ function multihistogram_NVT(
     results::Output,
     conv_threshold::Number,
     readfile::Bool;
-    debug=false,
+    max_iter=1000,
+    show_progress=true,
 )
     if readfile == false
         tempnumber, tempnumber_result = temp_trajectories(temp)
@@ -114,10 +114,9 @@ function multihistogram_NVT(
         ENhistogram, Ebins, tempnumber, tempnumber_result
     )
 
-    for it in 1:1000
-        println("iteration=", it)
+    progress = ProgressThresh(conv_threshold; enabled=show_progress)
+    for it in 1:max_iter
         for i in 1:tempnumber
-            local betat
             betat = beta[i]
             new_free_energy[i] = 0
             for m in 1:Ebins
@@ -134,24 +133,18 @@ function multihistogram_NVT(
                         free_energy,
                     )
             end
-
-            #println(new_free_energy[i])
             new_free_energy[i] = log(new_free_energy[i])
-            #println(new_free_energy[i])
         end
 
-        local delta
-        delta = 0
+        delta = 0.0
         for i in 1:tempnumber
             delta = delta + abs(new_free_energy[i] - free_energy[i])^2
             free_energy[i] = new_free_energy[i]
         end
-        println(delta)
-        println()
 
+        update!(progress, delta)
         if delta < conv_threshold
-            println("iteration finished")
-            break             #if converged, exit the loop
+            break
         end
     end
 
@@ -208,16 +201,9 @@ function multihistogram_NVT(
                     free_energy,
                 ) / normalconst[i] * energy_t^2
         end
-        println("temperature: ", temp_result[i])
-        println("energy: ", eenergy)
-        println("heat capacity: ", (eenergy2 - eenergy^2) / (k * temp_result[i]^2))
-        println()
         cv[i] = (eenergy2 - eenergy^2) / (k * temp_result[i]^2)
     end
-    println("temperature array: ", temp_result)
-    println("heat capacity array: ", cv)
-
-    return cv
+    return (; T=temp_result, C=cv)
 end
 
 end

--- a/src/multihist_NVT.jl
+++ b/src/multihist_NVT.jl
@@ -98,7 +98,7 @@ function multihistogram_NVT(
     conv_threshold::Number,
     readfile::Bool;
     max_iter=1000,
-    show_progress=true,
+    show_progress=isinteractive(),
 )
     if readfile == false
         tempnumber, tempnumber_result = temp_trajectories(temp)

--- a/src/swap_config.jl
+++ b/src/swap_config.jl
@@ -10,9 +10,7 @@ Implemented for the following `move_type`:
 -   `swapmove` for atom swaps
 All methods also call the [`swap_vars!`](@ref) function which distributes the appropriate `mc_states.potential_variables` values into the current `mc_state` struct.
 """
-function swap_config!(
-    mc_state::MCState{T,BC,P,E}, movetype::String
-) where {T,BC,P<:AbstractPotentialVariables,E<:AbstractEnsembleVariables}
+function swap_config!(mc_state, movetype::String)
     if movetype == "atommove"
         swap_atom_config!(
             mc_state,
@@ -36,9 +34,7 @@ end
 """
     swap_atom_config!(mc_state::MCState{T, N, BC, P, E}, i_atom::Int, trial_pos::PositionVector) where {T, N, BC, P <: AbstractPotentialVariables, E <: AbstractEnsembleVariables}
 """
-function swap_atom_config!(
-    mc_state::MCState{T,BC,P,E}, i_atom::Int, trial_pos::PositionVector
-) where {T,BC,P<:AbstractPotentialVariables,E<:AbstractEnsembleVariables}
+function swap_atom_config!(mc_state, i_atom, trial_pos)
     mc_state.config[i_atom] = trial_pos
     mc_state.dist2_mat[i_atom, :] = mc_state.new_dist2_vec
     mc_state.dist2_mat[:, i_atom] = mc_state.new_dist2_vec
@@ -56,57 +52,7 @@ end
 
 Swaps `mc_state`s and ensemble variables in case of accepted volume move for NPT ensemble.
 Implemented for [`CubicBC`](@ref Main.ParallelTemperingMonteCarlo.BoundaryConditions.CubicBC) and [`RhombicBC`](@ref Main.ParallelTemperingMonteCarlo.BoundaryConditions.RhombicBC)
-    """
-#=
-function swap_config_v!(
-    mc_state::MCState,
-    _,
-    bc::CubicBC,
-    trial_config::Config,
-    new_dist2_mat,
-    en_vec_new,
-    new_en_tot,
-)
-    mc_state.config = Config(trial_config, trial_config.boundary_condition)
-    mc_state.dist2_mat .= new_dist2_mat
-    mc_state.potential_variables.en_atom_vec .= en_vec_new
-
-    mc_state.en_tot = new_en_tot
-    mc_state.count_vol[1] += 1
-    mc_state.count_vol[2] += 1
-
-end
-
-function swap_config_v!(
-    mc_state::MCState,
-    _,
-    bc::RhombicBC,
-    trial_config::Config,
-    new_dist2_mat,
-    en_vec_new,
-    new_en_tot,
-)
-    mc_state.config = Config(trial_config, trial_config.boundary_condition)
-
-    mc_state.dist2_mat .= new_dist2_mat
-    mc_state.potential_variables.en_atom_vec .= en_vec_new
-    mc_state.potential_variables.en_atom_vec .= en_vec_new
-
-    mc_state.en_tot = new_en_tot
-    if mc_state.ensemble_variables.xy_or_z==0
-        mc_state.count_vol[1] += 1
-        mc_state.count_vol[2] += 1
-    elseif mc_state.ensemble_variables.xy_or_z==1
-        mc_state.count_vol_xy[1] += 1
-        mc_state.count_vol_xy[2] += 1
-    else
-        mc_state.count_vol_z[1] += 1
-        mc_state.count_vol_z[2] += 1
-    end
-
-end
-=#
-
+"""
 function swap_config_v!(
     mc_state::MCState,
     potential_variables::DimerPotentialVariables,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,6 @@
 [deps]
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/move-consistency.jl
+++ b/test/move-consistency.jl
@@ -17,8 +17,8 @@ function mc_move_deterministic!(accept, mc_state, move_strat, pot, ensemble)
     mc_state.ensemble_variables.index = index = rand(eachindex(move_strat.movestrat))
     move = move_strat.movestrat[index]
 
-    generate_move!(mc_state, move, ensemble)
-    get_energy!(mc_state, pot, move)
+    generate_move!(mc_state, move)
+    get_energy!(mc_state, move)
 
     if accept
         swap_config!(mc_state, move)

--- a/test/move-consistency.jl
+++ b/test/move-consistency.jl
@@ -120,7 +120,7 @@ end
         @testset "$id" begin
             move_strategy = MoveStrategy(ensemble)
             mc_state = MCState(
-                temp.t_grid[5], temp.beta_grid[5], config, ensemble, potential
+                temp.t_grid[5], config, ensemble, potential
             )
 
             true_dist2 = get_distance2_mat(config)

--- a/test/move-consistency.jl
+++ b/test/move-consistency.jl
@@ -119,9 +119,7 @@ end
 
         @testset "$id" begin
             move_strategy = MoveStrategy(ensemble)
-            mc_state = MCState(
-                temp.t_grid[5], config, ensemble, potential
-            )
+            mc_state = MCState(temp.t_grid[5], config, ensemble, potential)
 
             true_dist2 = get_distance2_mat(config)
             @test mc_state.dist2_mat == true_dist2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -275,11 +275,15 @@ end
 end
 
 @safetestset "Saveconfigs" begin
-    include(joinpath(@__DIR__, "ne13_test.jl"))
+    include("ne13_test.jl")
 end
 
 @safetestset "Move consistency" begin
-    include(joinpath(@__DIR__, "move-consistency.jl"))
+    include("move-consistency.jl")
+end
+
+@safetestset "statistic tracking" begin
+    include("statistic-tracking.jl")
 end
 
 @testset "scripts run without errors" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,7 +215,7 @@ end
         (temp1.t_grid[n_traj] - temp1.t_grid[n_traj - 1])
 end
 
-@testset "Separated_volume_change" begin
+@safetestset "Separated_volume_change" begin
     include("separated_v_test.jl")
 end
 
@@ -223,11 +223,11 @@ end
     include("test_runner_forward.jl")
 end
 
-@testset "Potentials" begin
+@safetestset "Potentials" begin
     include("test_potentials.jl")
 end
 
-@testset "States" begin
+@safetestset "States" begin
     include("test_states.jl")
 end
 

--- a/test/separated_v_test.jl
+++ b/test/separated_v_test.jl
@@ -1,4 +1,5 @@
-using Random
+using ParallelTemperingMonteCarlo
+using Random, Test, StaticArrays
 
 @testset "separated_scale" begin
     v1 = SVector(1.0, 2.0, 3.0)
@@ -44,7 +45,7 @@ end
 
     temp = TempGrid{2}(10, 15)
 
-    state = MCState(temp.t_grid[1], temp.beta_grid[1], conf, ensemble, pot1)
+    state = MCState(temp.t_grid[1], conf, ensemble, pot1)
 
     state_new = volume_change(state)
 
@@ -105,7 +106,7 @@ end
 
     temp = TempGrid{2}(10, 15)
 
-    state = MCState(temp.t_grid[1], temp.beta_grid[1], conf, ensemble, potB)
+    state = MCState(temp.t_grid[1], conf, ensemble, potB)
 
     @test state.potential_variables.tan_mat[1, 2] ≈ 0.7453559924999299 #TODO: sign difference
     @test state.potential_variables.tan_mat[1, 3] ≈ 0.47140452079103173

--- a/test/statistic-tracking.jl
+++ b/test/statistic-tracking.jl
@@ -1,0 +1,99 @@
+using ParallelTemperingMonteCarlo, Test, Arrow
+
+using Random, DataFrames
+
+function run_full_computation(; flush_interval)
+    Random.seed!(1234)
+
+    n_atoms = 32
+    pressure = 101325
+    AtoBohr = 1.8897261259077824
+
+    n_traj = 24
+    temp = TempGrid{n_traj}(10, 25)
+
+    max_displ_atom = [0.1 * √(0.05 * temp.t_grid[i]) for i in 1:n_traj]
+    mc_params = MCParams(1000, n_traj, n_atoms; mc_sample=1, n_adjust=100)
+
+    c = [
+        -10.5097942564988,
+        989.725135614556,
+        -101383.865938807,
+        3918846.12841668,
+        -56234083.4334278,
+        288738837.441765,
+    ]
+    pot = ELJPotentialEven{6}(c)
+
+    separated_volume = false
+    ensemble = NPT(n_atoms, pressure * 2.2937122783969076e-13 / AtoBohr^3, separated_volume)
+    move_strat = MoveStrategy(ensemble)
+
+    # Face centred cubic structure.
+    pos_ne32 = [
+        [-4.3837, -4.3837, -4.3837],
+        [-2.1918, -2.1918, -4.3837],
+        [-2.1918, -4.3837, -2.1918],
+        [-4.3837, -2.1918, -2.1918],
+        [-4.3837, -4.3837, 0.0000],
+        [-2.1918, -2.1918, 0.0000],
+        [-2.1918, -4.3837, 2.1918],
+        [-4.3837, -2.1918, 2.1918],
+        [-4.3837, 0.0000, -4.3837],
+        [-2.1918, 2.1918, -4.3837],
+        [-2.1918, 0.0000, -2.1918],
+        [-4.3837, 2.1918, -2.1918],
+        [-4.3837, 0.0000, 0.0000],
+        [-2.1918, 2.1918, 0.0000],
+        [-2.1918, 0.0000, 2.1918],
+        [-4.3837, 2.1918, 2.1918],
+        [0.0000, -4.3837, -4.3837],
+        [2.1918, -2.1918, -4.3837],
+        [2.1918, -4.3837, -2.1918],
+        [0.0000, -2.1918, -2.1918],
+        [0.0000, -4.3837, 0.0000],
+        [2.1918, -2.1918, 0.0000],
+        [2.1918, -4.3837, 2.1918],
+        [0.0000, -2.1918, 2.1918],
+        [0.0000, 0.0000, -4.3837],
+        [2.1918, 2.1918, -4.3837],
+        [2.1918, 0.0000, -2.1918],
+        [0.0000, 2.1918, -2.1918],
+        [0.0000, 0.0000, 0.0000],
+        [2.1918, 2.1918, 0.0000],
+        [2.1918, 0.0000, 2.1918],
+        [0.0000, 2.1918, 2.1918],
+    ]
+
+    positions = pos_ne32 * AtoBohr
+    box_length = 8.7674 * AtoBohr
+    boundary_condition = CubicBC(box_length)
+
+    start_config = Config(positions, boundary_condition)
+    ptmc_run!(
+        mc_params, temp, start_config, pot, ensemble;
+        stats_filename="test.arrow", flush_interval,
+    )
+end
+
+@testset "Statistic tracking" begin
+    _, _, stats1 = run_full_computation(; flush_interval=100)
+    _, _, stats2 = run_full_computation(; flush_interval=10000)
+
+    @test size(stats1) == size(stats2) == (26400, 13)
+
+    @test stats1 == DataFrame(Arrow.Table("test.arrow"))
+    @test stats2 == DataFrame(Arrow.Table("test-1.arrow"))
+
+    @test stats1.hamiltonian ≈ stats1.total_energy .+ stats1.volume .* 3.4439667494478555e-9
+
+    i = 1
+    if isfile("test.arrow")
+        rm("test.arrow")
+        while isfile("test-$i.arrow")
+            rm("test-$i.arrow")
+            i += 1
+        end
+    end
+    @test i == 2
+end

--- a/test/statistic-tracking.jl
+++ b/test/statistic-tracking.jl
@@ -1,6 +1,4 @@
-using ParallelTemperingMonteCarlo, Test, Arrow
-
-using Random, DataFrames
+using ParallelTemperingMonteCarlo, Test, Arrow, Random, DataFrames
 
 function run_full_computation(; flush_interval)
     Random.seed!(1234)

--- a/test/test_potentials.jl
+++ b/test/test_potentials.jl
@@ -1,3 +1,6 @@
+using Test
+using ParallelTemperingMonteCarlo
+using StaticArrays
 using ParallelTemperingMonteCarlo.MachineLearningPotential.ForwardPass: lib_path
 
 @testset "ELJPotentials" begin

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -1,4 +1,5 @@
-using Random
+using ParallelTemperingMonteCarlo
+using Random, Test, StaticArrays
 
 @testset "States" begin
     v1 = SVector(1.0, 2.0, 3.0)
@@ -14,8 +15,8 @@ using Random
 
     temp = TempGrid{2}(10, 15)
 
-    state = MCState(temp.t_grid[1], temp.beta_grid[1], conf1, ensemble, pot1)
-    state2 = MCState(temp.t_grid[2], temp.beta_grid[2], conf1, ensemble, pot1)
+    state = MCState(temp.t_grid[1], conf1, ensemble, pot1)
+    state2 = MCState(temp.t_grid[2], conf1, ensemble, pot1)
     @test state.ensemble_variables isa NVTVariables{Float64}
     @test state.potential_variables isa DimerPotentialVariables
 
@@ -58,8 +59,8 @@ end
 
     temp = TempGrid{2}(10, 15)
 
-    state = MCState(temp.t_grid[1], temp.beta_grid[1], conf1, ensemble, pot1)
-    state2 = MCState(temp.t_grid[2], temp.beta_grid[2], conf1, ensemble, pot1)
+    state = MCState(temp.t_grid[1], conf1, ensemble, pot1)
+    state2 = MCState(temp.t_grid[2], conf1, ensemble, pot1)
 
     @test state.ensemble_variables isa NPTVariables{Float64}
     @test state.potential_variables isa DimerPotentialVariables
@@ -105,9 +106,9 @@ end
     nnvtens = NNVT([4, 2])
     temp = TempGrid{2}(500, 650)
 
-    state = MCState(temp.t_grid[1], temp.beta_grid[1], conf, nnvtens, runnerpotential)
-    state2 = MCState(temp.t_grid[2], temp.beta_grid[2], conf, nnvtens, runnerpotential)
-    refstate = MCState(temp.t_grid[1], temp.beta_grid[1], conf, nnvtens, runnerpotential)
+    state = MCState(temp.t_grid[1], conf, nnvtens, runnerpotential)
+    state2 = MCState(temp.t_grid[2], conf, nnvtens, runnerpotential)
+    refstate = MCState(temp.t_grid[1], conf, nnvtens, runnerpotential)
 
     @test isa(state.ensemble_variables, NNVTVariables)
     @test isa(state.potential_variables, NNPVariables2a)

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -26,9 +26,9 @@ using Random, Test, StaticArrays
     state.ensemble_variables.index = 1
 
     Random.seed!(1234)
-    generate_move!(state, "atommove", ensemble)
+    generate_move!(state, "atommove")
 
-    state = get_energy!(state, pot1, "atommove")
+    state = get_energy!(state, "atommove")
     @test state.new_en - state.en_tot ≈ -4.99895252855e-5
     @test metropolis_condition("atommove", state, ensemble) == 1.0
     @test_throws ErrorException metropolis_condition("evommota", state, ensemble)
@@ -72,9 +72,9 @@ end
     Random.seed!(1234)
 
     Random.seed!(1234)
-    generate_move!(state, "atommove", ensemble)
+    generate_move!(state, "atommove")
 
-    state = get_energy!(state, pot1, "atommove")
+    state = get_energy!(state, "atommove")
     @test state.new_en - state.en_tot ≈ -4.99895252855e-5
     @test metropolis_condition("atommove", state, ensemble) == 1.0
 
@@ -129,9 +129,9 @@ end
 
     #test moves
     Random.seed!(123)
-    generate_move!(state, "atommove", nnvtens)
+    generate_move!(state, "atommove")
 
-    state = get_energy!(state, runnerpotential, "atommove")
+    state = get_energy!(state, "atommove")
     delen = state.new_en - state.en_tot
     @test delen ≈ -7.5971516e-5
     #test exc after atom move
@@ -147,11 +147,11 @@ end
     Random.seed!(123)
     MCMoves.swap_atoms(state)
     @test state.ensemble_variables.swap_indices[2] > 4
-    state = get_energy!(state, runnerpotential, "atomswap")
+    state = get_energy!(state, "atomswap")
     delen2 = state.new_en - state.en_tot
     @test delen2 ≈ -0.0017084901948
 
-    MCRun.acc_test!(state, nnvtens, "atomswap")
+    MCRun.acc_test!(state, "atomswap")
 
     refmat = copy(refstate.dist2_mat[6, :])
     refmat[6] = refstate.dist2_mat[6, 3]


### PR DESCRIPTION
## New features
- Stats such as the `hamiltonian` value, total energy, acceptance, etc. are stored and returned by `ptmc_run!`.
- Progress bars for MC and multihistogram analysis.
- `potential` and `ensemble` are now stored in each `MCState`.

## Example usage
```julia
using ParallelTemperingMonteCarlo, DataFrames

# do some setup here...

mc_states, results, stats = ptmc_run!(mc_params, temp, start_config, pot, ensemble)
DataFrame(stats)
```